### PR TITLE
Added README as PyPI publish requires

### DIFF
--- a/packages/gsm8k/README.md
+++ b/packages/gsm8k/README.md
@@ -1,0 +1,23 @@
+# aviary.gsm8k
+
+GSM8k environment implemented with aviary.
+
+## Citation
+
+The citation for GSM8k is given below:
+
+```bibtex
+@article{gsm8k-paper,
+    title = {Training verifiers to solve math word problems},
+    author = {Cobbe, Karl and Kosaraju, Vineet and Bavarian, Mohammad and Chen, Mark and Jun, Heewoo and Kaiser, Lukasz and
+ Plappert, Matthias and Tworek, Jerry and Hilton, Jacob and Nakano, Reiichiro and others},
+    journal = {arXiv preprint arXiv:2110.14168},
+    year = {2021}
+}
+```
+
+## References
+
+[1] Cobbe, K., Kosaraju, V., Bavarian, M., Chen, M., Jun, H., Kaiser, L., Plappert, M., Tworek, J., Hilton, J., Nakano,
+R. and Hesse, C., 2021.
+[Training verifiers to solve math word problems](https://arxiv.org/abs/2110.14168). arXiv preprint arXiv:2110.14168.

--- a/packages/gsm8k/pyproject.toml
+++ b/packages/gsm8k/pyproject.toml
@@ -14,6 +14,7 @@ dependencies = [
 description = "GSM8k environment implemented with aviary"
 dynamic = ["version"]
 name = "aviary.gsm8k"
+readme = "README.md"
 requires-python = ">=3.11"
 
 [project.optional-dependencies]

--- a/packages/hotpotqa/README.md
+++ b/packages/hotpotqa/README.md
@@ -1,0 +1,12 @@
+# aviary.hotpotqa
+
+HotPotQA environment implemented with aviary.
+
+## References
+
+[1] Yang et al. [HotpotQA: A Dataset for Diverse,
+Explainable Multi-Hop Question Answering](https://aclanthology.org/D18-1259/). EMNLP, 2018.
+
+[2] Yao et al.,
+[ReAct: Synergizing Reasoning and Acting in Language Models](https://openreview.net/forum?id=WE_vluYUL-X).
+In The Eleventh International Conference on Learning Representations. 2023

--- a/packages/hotpotqa/pyproject.toml
+++ b/packages/hotpotqa/pyproject.toml
@@ -17,6 +17,7 @@ dependencies = [
 description = "HotPotQA environment implemented with aviary"
 dynamic = ["version"]
 name = "aviary.hotpotqa"
+readme = "README.md"
 requires-python = ">=3.11"
 
 [tool.ruff]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ dependencies = [
 description = "Gymnasium framework for training language model agents on constructive tasks"
 dynamic = ["version"]
 name = "fhaviary"
+readme = "README.md"
 requires-python = ">=3.11"
 
 [project.optional-dependencies]


### PR DESCRIPTION
Coming from https://github.com/Future-House/aviary/actions/runs/10624512973:

```
ERROR    `long_description` has syntax errors in markup and would not be        
         rendered on PyPI.                                                      
         No content rendered from RST source.    
```

Seems a `readme` field is required