### PR TITLE
`uv lock` protection

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -61,6 +61,10 @@ repos:
       - id: validate-pyproject
         additional_dependencies:
           - "validate-pyproject-schema-store[all]>=2024.08.19" # For Ruff renaming RUF025 to C420
+  - repo: https://github.com/astral-sh/uv-pre-commit
+    rev: 0.4.4
+    hooks:
+      - id: uv-lock
   - repo: https://github.com/pre-commit/mirrors-mypy
     rev: v1.11.2
     hooks:


### PR DESCRIPTION
This PR adds a `pre-commit` hook to check for a stale `uv.lock`