### PR TITLE
Adding a few `pytest` `filterwarnings` for clean test logs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -216,6 +216,14 @@ min-similarity-lines = 12
 # Add the specified OPTS to the set of command line arguments as if they had been
 # specified by the user.
 addopts = "--typeguard-packages=aviary --doctest-modules"
+# Sets a list of filters and actions that should be taken for matched warnings.
+# By default all warnings emitted during the test session will be displayed in
+# a summary at the end of the test session.
+filterwarnings = [
+    "ignore:'imghdr' is deprecated and slated for removal in Python 3.13:DeprecationWarning",  # SEE: https://github.com/BerriAI/litellm/issues/2929#issuecomment-2345224633
+    "ignore:Support for class-based `config` is deprecated, use ConfigDict instead",  # SEE: https://github.com/BerriAI/litellm/issues/5648
+    'ignore:open_text is deprecated. Use files\(\) instead:DeprecationWarning',  # SEE: https://github.com/BerriAI/litellm/issues/5647
+]
 # List of directories that should be searched for tests when no specific directories,
 # files or test ids are given in the command line when executing pytest from the rootdir
 # directory. File system paths may use shell-style wildcards, including the recursive **


### PR DESCRIPTION
Cleaning up our logs a bit.

I got all but one, I couldn't figure out the origin of this one:

```none
  /home/runner/work/aviary/aviary/.venv/lib/python3.12/site-packages/pydantic/_internal/_config.py:291: PydanticDeprecatedSince20: Support for class-based `config` is deprecated, use ConfigDict instead. Deprecated in Pydantic V2.0 to be removed in V3.0. See Pydantic V2 Migration Guide at https://errors.pydantic.dev/2.9/migration/
```