### PR TITLE
Document environments

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,3 +216,43 @@ def export_frame(self) -> Frame:
         info={"tool_names": [t.info.name for t in self.tools]},
     )
 ```
+
+## Environments
+
+### GSM8k Environment
+
+#### What it does
+
+The GSM8k environment allows agents to solve math word problems from the GSM8k dataset.
+
+#### Installation
+
+To install the GSM8k environment, run the following command:
+
+```bash
+pip install fhaviary[gsm8k]
+```
+
+### HotPotQA Environment
+
+#### What it does
+
+The HotPotQA environment allows agents to perform multi-hop question answering on the HotPotQA dataset.
+
+#### Installation
+
+To install the HotPotQA environment, run the following command:
+
+```bash
+pip install fhaviary[hotpotqa]
+```
+
+### PaperQA Environment
+
+#### What it does
+
+The PaperQA environment allows agents to perform question answering on the PaperQA dataset.
+
+#### Installation
+
+To install the PaperQA environment, follow the instructions in the [PaperQA repository](https://github.com/Future-House/paper-qa).

--- a/packages/gsm8k/README.md
+++ b/packages/gsm8k/README.md
@@ -21,3 +21,11 @@ The citation for GSM8k is given below:
 [1] Cobbe, K., Kosaraju, V., Bavarian, M., Chen, M., Jun, H., Kaiser, L., Plappert, M., Tworek, J., Hilton, J., Nakano,
 R. and Hesse, C., 2021.
 [Training verifiers to solve math word problems](https://arxiv.org/abs/2110.14168). arXiv preprint arXiv:2110.14168.
+
+## Installation
+
+To install the GSM8k environment, run the following command:
+
+```bash
+pip install fhaviary[gsm8k]
+```

--- a/packages/hotpotqa/README.md
+++ b/packages/hotpotqa/README.md
@@ -10,3 +10,11 @@ Explainable Multi-Hop Question Answering](https://aclanthology.org/D18-1259/). E
 [2] Yao et al.,
 [ReAct: Synergizing Reasoning and Acting in Language Models](https://openreview.net/forum?id=WE_vluYUL-X).
 In The Eleventh International Conference on Learning Representations. 2023
+
+## Installation
+
+To install the HotPotQA environment, run the following command:
+
+```bash
+pip install fhaviary[hotpotqa]
+```


### PR DESCRIPTION
Fixes #33

Add documentation for environments in `README.md`.

* Add a new section titled "Environments" in `README.md` with subsections for GSM8k, HotPotQA, and PaperQA environments.
  * Describe what each environment does and provide installation instructions.
* Update `packages/gsm8k/README.md` to include installation instructions for the GSM8k environment.
* Update `packages/hotpotqa/README.md` to include installation instructions for the HotPotQA environment.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/Future-House/aviary/issues/33?shareId=a5be1590-1422-48ff-9d4d-7924f26c4e1a).