### PR TITLE
Automerging non-major deps and `pre-commit`, restoring `lockFileMaintenance`

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,11 +1,14 @@
 {
   $schema: "https://docs.renovatebot.com/renovate-schema.json",
-  extends: ["config:recommended", ":enablePreCommit"],
+  extends: ["config:recommended"],
   schedule: ["* 2 * * 1"],
   prHourlyLimit: 4,
   timezone: "America/Los_Angeles",
   rangeStrategy: "widen",
   lockFileMaintenance: {
+    enabled: true,
+  },
+  "pre-commit": {
     enabled: true,
   },
   packageRules: [


### PR DESCRIPTION
https://github.com/Future-House/aviary/pull/48 was testing if we still needed `lockFileMaintenance`'s `enabled: true`. It turns out we still do, as it no longer shows up in the dependency dashboard.

This PR also now automerges non-major deps and `pre-commit`.