### PR TITLE
Fixed argref_by_name bug with kwargs

### DIFF
--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -646,8 +646,8 @@ async def test_argref_by_name_advanced_features() -> None:
 
     s = MyState()
 
-    # Define and test skip_deref with return_direct
-    @argref_by_name(skip_deref={"a"}, return_direct=True)
+    # Define and test dereference via no state value found with return_direct
+    @argref_by_name(return_direct=True)
     def skip_deref_test(foo: float, a: str) -> str:
         """Some docstring."""
         return f"{foo} {a}"


### PR DESCRIPTION
Found an awful dirty bug when using @argref_by_name. To route strings, I wrote it so if a kwarg is passed - like (foo='bar') instead of ('bar') then it will not try to dereference that string to an object from the state. However - SimpleAgent calls all tools via kwarg and ReactAgent calls all tools via args. So, ReactAgent looked great and SimpleAgent was passing strings around and breaking code.

I made it so that if strings are passed and if they do not match a key, just assume they're meant to be used as a literal. However, I did keep an error check if the first argument is a string and not found in state as a valid key, then it throws an error. 

I also cleaned up the function a bit and split up tests