### PR TITLE
HotPotQA preventing `None` answers

### DIFF
--- a/packages/hotpotqa/src/aviary/hotpotqa/env.py
+++ b/packages/hotpotqa/src/aviary/hotpotqa/env.py
@@ -169,7 +169,7 @@ class HotPotQAEnv(Environment[HotPotQAEnvState]):
     def __init__(
         self,
         question: str,
-        correct_answer: str,
+        correct_answer: str | float,
         correct_reward: float = 1.0,
         incorrect_reward: float = 0.0,
         tool_failure_reward: float = 0.0,
@@ -515,6 +515,14 @@ class HotPotQADataset(TaskDataset[HotPotQAEnv]):
                 f" please specify a split from {set(all_datasets.keys())}."
             ) from exc
 
+        if not all(  # Making up for datasets not being typed: https://github.com/huggingface/datasets/issues/3841
+            isinstance(d["question"], str) and isinstance(d["answer"], str | float)
+            for d in data
+        ):
+            raise ValueError(
+                f"Dataset {hf_dataset!r} and split {split!r} contains invalid"
+                " question(s) or answer(s)."
+            )
         return [(d["question"], d["answer"]) for d in data if self._filter_task(d)]
 
     def __init__(

--- a/packages/hotpotqa/tests/test_hotpotqa_env.py
+++ b/packages/hotpotqa/tests/test_hotpotqa_env.py
@@ -1,3 +1,5 @@
+import pytest
+
 from aviary.env import Environment, TaskDataset
 from aviary.hotpotqa import HotPotQAEnv
 
@@ -20,3 +22,6 @@ def test_dataset_from_name() -> None:
         "hotpotqa", split="train", difficulty_level={"easy", "hard"}
     )
     assert len(dataset) == 33633
+
+    with pytest.raises(ValueError, match="answer"):
+        TaskDataset.from_name("hotpotqa", split="test")


### PR DESCRIPTION
It turns out the `tests` split in the `fullwiki` dataset of https://huggingface.co/datasets/hotpotqa/hotpot_qa has `None` values for all `answer`s. This silently got past us here because:
1. https://github.com/huggingface/datasets is not typed
2. We didn't use the `test` split in testing, so `typeguard` missed it

This PR fixes that vulnerability