### PR TITLE
Reverted back to `pypa/gh-action-pypi-publish` for publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -19,6 +19,7 @@ jobs:
           uv build --sdist --wheel --out-dir dist/ .
           uv build --sdist --wheel --out-dir dist/ packages/gsm8k
           uv build --sdist --wheel --out-dir dist/ packages/hotpotqa
-      - run: uv publish
-        env:
-          UV_PUBLISH_TOKEN: ${{ secrets.PYPI_API_TOKEN }}
+      # TODO: go back to `uv publish` after https://github.com/astral-sh/uv/issues/8030
+      - uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          password: ${{ secrets.PYPI_API_TOKEN }}


### PR DESCRIPTION
https://github.com/Future-House/aviary/pull/63 moved us to use `uv publish`, but per [this CI run](https://github.com/Future-House/aviary/actions/runs/11246421624/job/31268216120), we can see `uv publish` failed. I opened https://github.com/astral-sh/uv/issues/8030 to log this, and this PR temporarily reverts us to use `pypa/gh-action-pypi-publish`