### PR TITLE
Moving from `large-runner` to `ubuntu-latest` for CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -64,7 +64,7 @@ jobs:
       - if: matrix.python-version == '3.11' # Only need to run this on one version
         uses: suzuki-shunsuke/github-action-renovate-config-validator@v1.1.0
   test:
-    runs-on: large-runner
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: astral-sh/setup-uv@v3

--- a/uv.lock
+++ b/uv.lock
@@ -173,7 +173,7 @@ wheels = [
 
 [[package]]
 name = "aviary-gsm8k"
-version = "0.8.4.dev3+ga3d1068"
+version = "0.8.4.dev4+gc705897.d20241028"
 source = { editable = "packages/gsm8k" }
 dependencies = [
     { name = "datasets" },
@@ -196,7 +196,7 @@ requires-dist = [
 
 [[package]]
 name = "aviary-hotpotqa"
-version = "0.8.4.dev3+ga3d1068"
+version = "0.8.4.dev4+gc705897.d20241028"
 source = { editable = "packages/hotpotqa" }
 dependencies = [
     { name = "beautifulsoup4" },
@@ -542,7 +542,7 @@ wheels = [
 
 [[package]]
 name = "fhaviary"
-version = "0.8.4.dev3+ga3d1068"
+version = "0.8.4.dev4+gc705897.d20241028"
 source = { editable = "." }
 dependencies = [
     { name = "docstring-parser" },
@@ -614,7 +614,7 @@ xml = [
     { name = "dicttoxml" },
 ]
 
-[package.dependency-groups]
+[package.dev-dependencies]
 dev = [
     { name = "aviary-gsm8k", extra = ["typing"] },
     { name = "aviary-hotpotqa" },
@@ -686,7 +686,7 @@ requires-dist = [
     { name = "uvicorn", marker = "extra == 'server'" },
 ]
 
-[package.metadata.dependency-groups]
+[package.metadata.requires-dev]
 dev = [{ name = "fhaviary", extras = ["dev"], editable = "." }]
 
 [[package]]


### PR DESCRIPTION
This PR removes the `large-runner` in favor of `ubuntu-latest` because:

- We don't need the `large-runner` in aviary, CI is lightweight
- `large-runner` is a FutureHouse internal runner, and now this repo is open source

Also, I ran `uv lock` for `uv` changing from `[package.metadata.dependency-groups]` to `[package.metadata.requires-dev]`