### PR TITLE
Fixing CI by downpinning `uv<0.5`

### DIFF
--- a/.github/workflows/codeflash.yml
+++ b/.github/workflows/codeflash.yml
@@ -38,6 +38,7 @@ jobs:
         uses: astral-sh/setup-uv@v3
         with:
           enable-cache: true
+          version: 0.4.30
       - if: steps.bot_check.outputs.skip_remaining_steps == 'no'
         run: uv sync --group=codeflash
       - name: Run CodeFlash on fhaviary

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -31,6 +31,7 @@ jobs:
       - uses: astral-sh/setup-uv@v3
         with:
           enable-cache: true
+          version: 0.4.30
       - run: uv python pin ${{ matrix.python-version }}
       - name: Check fhaviary build
         if: matrix.python-version == '3.11'
@@ -70,6 +71,7 @@ jobs:
       - uses: astral-sh/setup-uv@v3
         with:
           enable-cache: true
+          version: 0.4.30
       - run: uv sync
       - name: Cache datasets
         uses: actions/cache@v4


### PR DESCRIPTION
From [this CI run](https://github.com/Future-House/aviary/actions/runs/11737578015/job/32698600441), we get:

```none
  × No solution found when resolving dependencies for split
  │ (python_full_version == '3.11.*' and platform_python_implementation ==
  │ 'PyPy'):
  ╰─▶ Because only the following versions of paper-qa are available:
          paper-qa<=5.0.0
          paper-qa==5.0.1
...
          paper-qa==5.3.2
      and paper-qa==5.3.2 depends on fhaviary, we can conclude that
      paper-qa>5.3.1 depends on fhaviary.
      And because paper-qa>=5.0.0,<=5.3.1 depends on fhaviary, we can conclude
      that paper-qa>=5.0.0 depends on fhaviary.
      And because fhaviary[paperqa] depends on paper-qa>=5 and your workspace
      requires fhaviary[paperqa], we can conclude that your workspace's
      requirements are unsatisfiable.

      hint: The package `paper-qa` depends on the package `fhaviary` but the
      name is shadowed by one of your workspace members. Consider changing the
      name of the workspace member.
```

Something about `uv==0.5.0` broke our "circular" pinning with `paper-qa` (where `paper-qa` depends on `fhaviary`, and we have a convenience `paperqa` extra here). This PR just temporarily down-pins `uv` for this