### PR TITLE
Adding `fetch-depth` to `actions/checkout` to fix CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,6 +15,8 @@ jobs:
         python-version: [3.11, 3.13] # Our min and max supported Python versions
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # For setuptools-scm, replace with fetch-tags after https://github.com/actions/checkout/issues/1471
       - uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
@@ -28,6 +30,8 @@ jobs:
         python-version: [3.11, 3.13] # Our min and max supported Python versions
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # For setuptools-scm, replace with fetch-tags after https://github.com/actions/checkout/issues/1471
       - uses: astral-sh/setup-uv@v3
         with:
           enable-cache: true
@@ -67,6 +71,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # For setuptools-scm, replace with fetch-tags after https://github.com/actions/checkout/issues/1471
       - uses: astral-sh/setup-uv@v3
         with:
           enable-cache: true


### PR DESCRIPTION
From [this CI run](https://github.com/Future-House/aviary/actions/runs/11737578015/job/32698600441), we get:

```none
  × No solution found when resolving dependencies for split
  │ (python_full_version == '3.11.*' and platform_python_implementation ==
  │ 'PyPy'):
  ╰─▶ Because only the following versions of paper-qa are available:
          paper-qa<=5.0.0
          paper-qa==5.0.1
...
          paper-qa==5.3.2
      and paper-qa==5.3.2 depends on fhaviary, we can conclude that
      paper-qa>5.3.1 depends on fhaviary.
      And because paper-qa>=5.0.0,<=5.3.1 depends on fhaviary, we can conclude
      that paper-qa>=5.0.0 depends on fhaviary.
      And because fhaviary[paperqa] depends on paper-qa>=5 and your workspace
      requires fhaviary[paperqa], we can conclude that your workspace's
      requirements are unsatisfiable.

      hint: The package `paper-qa` depends on the package `fhaviary` but the
      name is shadowed by one of your workspace members. Consider changing the
      name of the workspace member.
```

This is related to our "circular" pinning with `paper-qa` (where `paper-qa` depends on `fhaviary`, and we have a convenience `paperqa` extra here). Note that `paper-qa` currently pins ``fhaviary[llm]>=0.8.2`.

https://github.com/Future-House/aviary/pull/117 tried to fix this by downpinning `uv<0.5`, but that didn't work. So this PR looks closer, and realizes in [this CI run's logs](https://github.com/Future-House/aviary/actions/runs/11747524651/job/32729622406) for `uv sync --verbose`:

```none
Installed 124 packages in 121ms
...
 + fhaviary==0.1.dev1+g6ddf4a0 (from file:///home/runner/work/aviary/aviary)
```

This is incorrect! So this leads me to https://github.com/pypa/setuptools-scm/issues/952, where I realized we ned to add `fetch-depth: 0` so the correct version of `fhaviary` gets used in CI.

Someday after https://github.com/actions/checkout/issues/1471 we can just use `fetch-tags: true`.