### PR TITLE
`mypy` ignoring `cloudpickle` as it's untyped

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -170,6 +170,7 @@ warn_unused_ignores = true
 ignore_missing_imports = true
 # Per-module configuration options
 module = [
+    "cloudpickle",  # SEE: https://github.com/cloudpipe/cloudpickle/issues/541
     "datasets",  # SEE: https://github.com/huggingface/datasets/issues/3841
     "dicttoxml",  # SEE: https://github.com/quandyfactory/dicttoxml/issues/106
 ]


### PR DESCRIPTION
This fixes an error we see when locally running `mypy -p aviary`:

```none
src/aviary/tools/server.py:35:1: error: Skipping analyzing "cloudpickle": module is installed, but missing library stubs or py.typed marker  [import-untyped]
            import cloudpickle as pickle
    ^
src/aviary/tools/server.py:35:1: note: See https://mypy.readthedocs.io/en/stable/running_mypy.html#missing-imports
```