### PR TITLE
Handling `ordered` deprecation

### DIFF
--- a/packages/hotpotqa/src/aviary/envs/hotpotqa/env.py
+++ b/packages/hotpotqa/src/aviary/envs/hotpotqa/env.py
@@ -310,13 +310,10 @@ class HotPotQAEnv(Environment[HotPotQAEnvState]):
         self.state.reward = 0.0
         response_messages = cast(
             Messages,
-            # Ordered since things like search -> lookup need to be run in order.
+            # Non-concurrent since things like search -> lookup need to be run in order.
             # NOTE: Handling tool exceptions here keeps the trajectory going, but I don't
             # think the returned message is useful to the agent/learning. Disabling for now.
-            await self.exec_tool_calls(
-                action,
-                ordered=True,
-            ),
+            await self.exec_tool_calls(action, concurrency=False),
         )
         return response_messages, self.state.reward, self.state.done, False
 

--- a/src/aviary/env.py
+++ b/src/aviary/env.py
@@ -6,7 +6,6 @@ import inspect
 import json
 import logging
 import random
-import warnings
 from abc import ABC, abstractmethod
 from collections.abc import Iterator
 from copy import deepcopy
@@ -178,12 +177,6 @@ class Environment(ABC, Generic[TEnvState]):
             Ordered list of ToolResponseMessages, order matches the order of tool calls
                 in the input message.
         """
-        if (ordered := function_kwargs.pop("ordered", None)) is not None:
-            concurrency = not ordered
-            warnings.warn(
-                'Passing "ordered" as a keyword argument is deprecated and will be soon unsupported. ',
-                stacklevel=3,  # Make it easier to figure out which step() is causing the warning
-            )
 
         async def _exec_tool_call(tool_call: ToolCall) -> ToolResponseMessage:
             try:


### PR DESCRIPTION
#123 removed the `ordered` flag, but not all downstream environments have been updated. To deal with this, I am bringing the flag back and throwing a warning. We can properly deprecate it once everything has been updated.

I'm also fixing HotPotQA here for good measure. 