### PR TITLE
Implements new functional syntax

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -81,7 +81,7 @@ repos:
           - datasets
           - docstring_parser>=0.16 # Match aviary pyproject.toml
           - fastapi
-          - httpx
+          - httpx < 0.28 # Match aviary pyproject.toml
           - litellm
           - numpy
           - pydantic~=2.0 # Match aviary pyproject.toml

--- a/README.md
+++ b/README.md
@@ -111,13 +111,13 @@ Now we can define some tools:
 ```py
 @my_env.tool()
 def multiply(x: float, y: float) -> float:
-    """Multiply two numbers"""
+    """Multiply two numbers."""
     return x * y
 
 
 @my_env.tool()
 def print_story(story: str | bytes, state) -> None:
-    """Print a story to user and complete task"""
+    """Print a story to user and complete task."""
     print(story)
     state.reward = 1
     state.done = True

--- a/README.md
+++ b/README.md
@@ -14,7 +14,8 @@ Gymnasium framework for training language model agents on constructive tasks.
   - [Developer Installation](#developer-installation)
 - [Messages](#messages)
 - [Environment](#environment)
-  - [Environment subclass and state](#environment-subclass-and-state)
+- [Functional Environments](#functional-environments)
+- [Subclass Environments](#subclass-environments)
   - [Common environments](#common-environments)
   - [Tool](#tool)
     - [Advanced tool descriptions](#advanced-tool-descriptions)
@@ -88,9 +89,53 @@ to tools provided by the `reset`. The `obs_msgs` returned from the environment a
 general messages that are observations. The `reward` is a scalar value. The `done` is a boolean value. The `truncated`
 is a boolean value.
 
-Let's see a complete example for building an environment.
+## Functional Environments
 
-### Environment subclass and state
+The easiest way to create an environment is using the functional interface, which just uses functions and decorators to define environments. First, let's define what the environment looks like by defining its `start` function:
+
+```py
+from aviary import fenv
+
+
+@fenv.start()
+def my_env(topic):
+    return f"Write a story about {topic}", {"topic": topic}
+```
+
+Note that the decorator is a call (`start()`). The `start` decorator starts the definition of an environment. The function, `my_env`, can take whatever you would like and should return a tuple containing the first observation and anything you would like to store about the state of the environment (used to persist/share things between tools). The state will always automatically have an optional `reward` and a boolean `done` that indicates if the environment is complete.
+
+Now we can define some tools:
+
+```py
+@my_env.tool()
+def multiply(x: float, y: float) -> float:
+    """Multiply two numbers"""
+    return x * y
+
+
+@my_env.tool()
+def print_story(story: str | bytes, state) -> None:
+    """Print a story to user and complete task"""
+    print("A story about", state.extras["topic"])
+    print(story)
+    state.reward = 1
+    state.done = True
+```
+
+The tools will be converted into things visible for LLMs using the type hints and the variable descriptions. Thus, the type hinting can be valuable for the agent using it correctly. The docstrings are also passed to the LLM, and is the primary way (along with function name) for communicating about intended tool usage.
+
+The way to stop an environment or set a reward is via the `state` variable as shown the second tool. If the reward is not set, it is treated as zero.
+
+Now we can use our environment:
+
+```python
+env = my_env(topic="foo")
+obs, tools = await env.reset()
+```
+
+## Subclass Environments
+
+If you need more control over Environments and tools, you'll want to subclass the `Environment`
 
 First we define an environment by subclassing the `Environment` and defining a `state`. The `state` is all variables
 that change per step and we want to keep together. It will be accessible in your tools, so you can use it to store

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ from aviary import fenv
 
 @fenv.start()
 def my_env(topic):
-    return f"Write a story about {topic}", {"topic": topic}
+    return f"Write a story about {topic}", {"chosen_topic": topic}
 ```
 
 Note that the decorator is a call (`start()`). The `start` decorator starts the definition of an environment. The function, `my_env`, can take whatever you would like and should return a tuple containing the first observation and anything you would like to store about the state of the environment (used to persist/share things between tools). The state will always automatically have an optional `reward` and a boolean `done` that indicates if the environment is complete.

--- a/README.md
+++ b/README.md
@@ -99,7 +99,9 @@ from aviary import fenv
 
 @fenv.start()
 def my_env(topic):
-    return f"Write a story about {topic}", {"chosen_topic": topic}
+    # return first observation, and the starting environment state
+    # (empty in this case)
+    return f"Write a story about {topic}", {}
 ```
 
 Note that the decorator is a call (`start()`). The `start` decorator starts the definition of an environment. The function, `my_env`, can take whatever you would like and should return a tuple containing the first observation and anything you would like to store about the state of the environment (used to persist/share things between tools). The state will always automatically have an optional `reward` and a boolean `done` that indicates if the environment is complete.
@@ -116,7 +118,6 @@ def multiply(x: float, y: float) -> float:
 @my_env.tool()
 def print_story(story: str | bytes, state) -> None:
     """Print a story to user and complete task"""
-    print("A story about", state.extras["topic"])
     print(story)
     state.reward = 1
     state.done = True
@@ -124,7 +125,9 @@ def print_story(story: str | bytes, state) -> None:
 
 The tools will be converted into things visible for LLMs using the type hints and the variable descriptions. Thus, the type hinting can be valuable for the agent using it correctly. The docstrings are also passed to the LLM, and is the primary way (along with function name) for communicating about intended tool usage.
 
-The way to stop an environment or set a reward is via the `state` variable as shown the second tool. If the reward is not set, it is treated as zero.
+You can access the `state` variable in tools, which will have any fields you passed in the return tuple of `start()`. For example, if you returned `{'foo': 'bar'}`, then you could access `state.foo` in the tools.
+
+Stop an environment or set a reward via the `state` variable as shown the second tool. If the reward is not set, it is treated as zero.
 
 Now we can use our environment:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ classifiers = [
 ]
 dependencies = [
     "docstring_parser>=0.16",  # Pin for description addition
-    "httpx",
+    "httpx < 0.28",  # Pin until we remove app argument in clients that was deprecated in 0.28
     "pydantic~=2.0",
 ]
 description = "Gymnasium framework for training language model agents on constructive tasks"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,10 @@ codeflash = [
     "codeflash>=0.7",  # Pin to keep recent
     "fhaviary[dev]",
 ]
-dev = ["fhaviary[dev]"]
+dev = [
+    "fhaviary[dev]",
+    "httpx < 0.28",  # Pin until we remove app argument in clients that was deprecated in 0.28
+]
 
 [project]
 authors = [
@@ -24,7 +27,7 @@ classifiers = [
 ]
 dependencies = [
     "docstring_parser>=0.16",  # Pin for description addition
-    "httpx < 0.28",  # Pin until we remove app argument in clients that was deprecated in 0.28
+    "httpx",
     "pydantic~=2.0",
 ]
 description = "Gymnasium framework for training language model agents on constructive tasks"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,6 @@ codeflash = [
 ]
 dev = [
     "fhaviary[dev]",
-    "httpx < 0.28",  # Pin until we remove app argument in clients that was deprecated in 0.28
 ]
 
 [project]
@@ -45,6 +44,7 @@ dev = [
     "aviary.gsm8k[typing]",
     "aviary.hotpotqa",
     "fhaviary[image,llm,server,typing,xml]",
+    "httpx < 0.28",  # Pin until we remove app argument in clients that was deprecated in 0.28
     "ipython>=8",  # Pin to keep recent
     "mypy>=1.8",  # Pin for mutable-override
     "pre-commit>=3.4",  # Pin to keep recent

--- a/src/aviary/core.py
+++ b/src/aviary/core.py
@@ -15,7 +15,7 @@ from aviary.env_client import (
     TaskEnvClientState,
     TaskEnvironmentClient,
 )
-from aviary.functional import fenv
+from aviary.functional import DynamicState, fenv
 from aviary.message import EnvStateMessage, MalformedMessageError, Message, join
 from aviary.render import Renderer
 from aviary.tools import (
@@ -46,6 +46,7 @@ __all__ = [
     "DummyEnv",
     "DummyEnvState",
     "DummyTaskDataset",
+    "DynamicState",
     "EnvStateMessage",
     "Environment",
     "EnvironmentClient",

--- a/src/aviary/core.py
+++ b/src/aviary/core.py
@@ -15,6 +15,7 @@ from aviary.env_client import (
     TaskEnvClientState,
     TaskEnvironmentClient,
 )
+from aviary.functional import fenv
 from aviary.message import EnvStateMessage, MalformedMessageError, Message, join
 from aviary.render import Renderer
 from aviary.tools import (
@@ -75,6 +76,7 @@ __all__ = [
     "argref_by_name",
     "encode_image_to_base64",
     "eval_answer",
+    "fenv",
     "is_coroutine_callable",
     "join",
     "partial_format",

--- a/src/aviary/functional.py
+++ b/src/aviary/functional.py
@@ -4,10 +4,10 @@ from typing import Any
 
 from pydantic import BaseModel
 
-from .env import Environment, Frame
-from .message import Message
-from .tools import Messages, Tool, ToolRequestMessage
-from .utils import is_coroutine_callable
+from aviary.env import Environment, Frame
+from aviary.message import Message
+from aviary.tools import Messages, Tool, ToolRequestMessage
+from aviary.utils import is_coroutine_callable
 
 
 class DynamicState(BaseModel):

--- a/src/aviary/functional.py
+++ b/src/aviary/functional.py
@@ -139,7 +139,7 @@ class fenv:  # noqa: N801
         Example:
             @fenv.start()
             def my_env(topic: str):
-                return f"Write a story about {topic}", {"topic": topic}
+                return f"Write a story about {topic}", {"chosen_topic": topic}
 
             @my_env.tool()
             def print_story(story: str, state) -> None:
@@ -161,7 +161,7 @@ class fenv:  # noqa: N801
             - The state dict returned by the decorated function will automatically include
             'reward' (float) and 'done' (bool) fields that can be modified by tools
             - Tools can access the state dict via an optional 'state' parameter
-            - The environment implements the standard Gymnasium interface with async
+            - The environment implements the standard Aviary interface with async
             reset() and step() methods
         """
 

--- a/src/aviary/functional.py
+++ b/src/aviary/functional.py
@@ -4,8 +4,9 @@ from typing import Any
 
 from pydantic import BaseModel
 
-from .core import Environment, Frame, Message, Tool
-from .tools import Messages, ToolRequestMessage
+from .env import Environment, Frame
+from .message import Message
+from .tools import Messages, Tool, ToolRequestMessage
 from .utils import is_coroutine_callable
 
 
@@ -58,7 +59,7 @@ class FunctionalEnvironment(Environment[DynamicState]):
     async def reset(self) -> tuple[Messages, list[Tool]]:
         obs, extras = await self._call_start()
         self.state = DynamicState.from_extras(extras)
-        return [Message(content=str(obs), role="user")], self.tools
+        return [Message(content=obs, role="user")], self.tools
 
     async def step(
         self, action: ToolRequestMessage

--- a/src/aviary/functional.py
+++ b/src/aviary/functional.py
@@ -30,7 +30,10 @@ class DynamicState(BaseModel):
 
 
 class FunctionalEnvironment(Environment[DynamicState]):
-    """Environment class for function-based environments."""
+    """Environment class for function-based environments.
+
+    See @fenv.start() decorator for complete usage details.
+    """
 
     def __init__(
         self,
@@ -172,6 +175,7 @@ class fenv:  # noqa: N801
             - The state dict returned by the decorated function will automatically include
             'reward' (float) and 'done' (bool) fields that can be modified by tools
             - Tools can access the state dict via an optional 'state' parameter
+            - The environment should be done/conclude by setting 'state.done = True'
             - The environment implements the standard Aviary interface with async
             reset() and step() methods
         """

--- a/src/aviary/functional.py
+++ b/src/aviary/functional.py
@@ -64,6 +64,7 @@ class FunctionalEnvironment(Environment[DynamicState]):
         self, action: ToolRequestMessage
     ) -> tuple[Messages, float, bool, bool]:
         # just assume no concurrent to avoid user bugs
+        # TODO: could take config arguments in start() to enable concurrency
         msgs = await self.exec_tool_calls(action, state=self.state, concurrency=False)
         return msgs, self.state.reward, self.state.done, False
 

--- a/src/aviary/functional.py
+++ b/src/aviary/functional.py
@@ -133,7 +133,7 @@ class fenv:  # noqa: N801
         2. A dict of any state variables to persist between steps
 
         Args:
-            allow_concurrency (bool, optional): Whether to allow concurrent tool calls.
+            allow_concurrency (optional): Whether to allow concurrent tool calls.
             Defaults to False.
 
         Example:

--- a/src/aviary/functional.py
+++ b/src/aviary/functional.py
@@ -1,0 +1,164 @@
+from collections.abc import Callable
+from functools import update_wrapper
+from typing import Any
+
+from pydantic import BaseModel
+
+from .core import Environment, Frame, Message, Tool
+from .tools import Messages, ToolRequestMessage
+from .utils import is_coroutine_callable
+
+
+class DynamicState(BaseModel):
+    """Dynamic state model that adapts to provided extras."""
+
+    reward: float = 0
+    done: bool = False
+    extras: dict[str, Any] = {}
+
+    @classmethod
+    def from_extras(cls, extras: dict[str, Any]) -> "DynamicState":
+        """Create a state instance with the given extras."""
+        return cls(extras=extras)
+
+    def __getattr__(self, name: str):
+        """Allow direct access to extras as attributes."""
+        if name in self.extras:
+            return self.extras[name]
+        raise AttributeError(f"'State' has no attribute '{name}'")
+
+
+class FunctionalEnvironment(Environment[DynamicState]):
+    """Environment class for function-based environments."""
+
+    def __init__(self, start_fn: Callable, tools: list[Tool], *args, **kwargs):
+        super().__init__()
+        self.start_fn = start_fn
+        self.tools = tools
+        self.args = args
+        self.kwargs = kwargs
+        self.state = DynamicState()
+
+    async def _call_start(self) -> tuple[str, dict[str, Any]]:
+        """Call start_fn handling both sync and async cases."""
+        if is_coroutine_callable(self.start_fn):
+            result = await self.start_fn(*self.args, **self.kwargs)
+        else:
+            result = self.start_fn(*self.args, **self.kwargs)
+
+        if not isinstance(result, tuple) or len(result) != 2:  # noqa: PLR2004
+            raise TypeError("Start function must return (observation, state_dict)")
+
+        obs, state_dict = result
+        if not isinstance(state_dict, dict):
+            raise TypeError("State must be a dictionary")
+
+        return obs, state_dict
+
+    async def reset(self) -> tuple[Messages, list[Tool]]:
+        obs, extras = await self._call_start()
+        self.state = DynamicState.from_extras(extras)
+        return [Message(content=str(obs), role="user")], self.tools
+
+    async def step(
+        self, action: ToolRequestMessage
+    ) -> tuple[Messages, float, bool, bool]:
+        # just assume no concurrent to avoid user bugs
+        msgs = await self.exec_tool_calls(action, state=self.state, concurrency=False)
+        return msgs, self.state.reward, self.state.done, False
+
+    def export_frame(self) -> Frame:
+        """Export the current state of the environment."""
+        return Frame(
+            state={
+                "done": self.state.done,
+                "reward": self.state.reward,
+                "extras": self.state.extras,
+            },
+            info={
+                "tool_names": [t.info.name for t in self.tools],
+                "num_tools": len(self.tools),
+            },
+        )
+
+
+class EnvironmentBuilder:
+    """Builder class for constructing functional environments."""
+
+    def __init__(self, start_fn: Callable):
+        self.start_fn = start_fn
+        self.tools: list[Tool] = []
+        update_wrapper(self, start_fn)
+
+    def __call__(self, *args, **kwargs):
+        """Create a new environment instance."""
+        return FunctionalEnvironment(self.start_fn, self.tools.copy(), *args, **kwargs)
+
+    def tool(self, **tool_kwargs):
+        """Decorator to add tools to the environment."""
+
+        def decorator(func: Callable):
+            tool = Tool.from_function(
+                func, **tool_kwargs, allow_empty_param_descriptions=True
+            )
+            # Check for name conflicts
+            if any(t.info.name == tool.info.name for t in self.tools):
+                raise RuntimeError(f"Tool with name '{tool.info.name}' already exists")
+            self.tools.append(tool)
+            return func
+
+        return decorator
+
+
+class fenv:  # noqa: N801
+    """Factory class for creating functional environments."""
+
+    @staticmethod
+    def start():
+        """Initialize a new functional environment definition.
+
+        This decorator marks the starting point for defining a functional environment.
+        It should be applied to a function that sets up the initial state and first
+        observation for the environment. The decorated function will serve as the
+        base for adding tools via the .tool() decorator.
+
+        The decorated function should accept any desired parameters that configure
+        the environment instance. It must return a tuple containing:
+        1. The initial observation message (str)
+        2. A dict of any state variables to persist between steps
+
+        Example:
+            @fenv.start()
+            def my_env(topic: str):
+                return f"Write a story about {topic}", {"topic": topic}
+
+            @my_env.tool()
+            def print_story(story: str, state) -> None:
+                '''Print the story and complete the task'''
+                print(story)
+                state.reward = 1
+                state.done = True
+
+            # Usage
+            env = my_env(topic="space")
+            obs, tools = await env.reset()
+
+        Returns:
+            callable: A decorator function that transforms the decorated function into
+            an environment builder. The returned environment builder provides a .tool()
+            decorator for adding tools to the environment.
+
+        Notes:
+            - The state dict returned by the decorated function will automatically include
+            'reward' (float) and 'done' (bool) fields that can be modified by tools
+            - Tools can access the state dict via an optional 'state' parameter
+            - The environment implements the standard Gymnasium interface with async
+            reset() and step() methods
+        """
+
+        def decorator(func: Callable) -> EnvironmentBuilder:
+            if not callable(func):
+                raise TypeError("Decorator must be applied to a function")
+            return EnvironmentBuilder(func)
+
+        return decorator

--- a/tests/test_functional.py
+++ b/tests/test_functional.py
@@ -2,8 +2,8 @@ import asyncio
 
 import pytest
 
-from aviary.core import ToolCall, ToolRequestMessage
-from aviary.functional import FunctionalEnvironment, fenv
+from aviary.core import ToolCall, ToolRequestMessage, fenv
+from aviary.functional import FunctionalEnvironment
 
 
 # Fixtures

--- a/tests/test_functional.py
+++ b/tests/test_functional.py
@@ -6,7 +6,6 @@ from aviary.core import ToolCall, ToolRequestMessage, fenv
 from aviary.functional import FunctionalEnvironment
 
 
-# Fixtures
 @pytest.fixture
 def basic_env():
     @fenv.start()
@@ -110,7 +109,7 @@ async def test_invalid_start_function():
 async def test_invalid_state_dict():
     @fenv.start()
     def invalid_env():
-        return "Test", "not_a_dict"  # Should be a dict
+        return "Test", "not_a_dict"  # second arg should be a dict
 
     env = invalid_env()
     with pytest.raises(TypeError):

--- a/tests/test_functional.py
+++ b/tests/test_functional.py
@@ -138,7 +138,6 @@ async def test_frame_export(basic_env):
     assert isinstance(frame.info, dict)
     assert "tool_names" in frame.info
     assert frame.info["tool_names"] == ["test_tool"]
-    assert frame.info["num_tools"] == 1
 
 
 @pytest.mark.asyncio

--- a/tests/test_functional.py
+++ b/tests/test_functional.py
@@ -44,7 +44,7 @@ def test_environment_creation(basic_env):
 
 
 @pytest.mark.asyncio
-async def test_sync_env_reset(basic_env):
+async def test_basic_env_reset(basic_env):
     env = basic_env("test_param")
     obs, tools = await env.reset()
 

--- a/tests/test_functional.py
+++ b/tests/test_functional.py
@@ -1,0 +1,176 @@
+import asyncio
+
+import pytest
+
+from aviary.core import ToolCall, ToolRequestMessage
+from aviary.functional import FunctionalEnvironment, fenv
+
+
+# Fixtures
+@pytest.fixture
+def basic_env():
+    @fenv.start()
+    def test_env(param: str):
+        return f"Test {param}", {"param": param}
+
+    @test_env.tool()
+    def test_tool(x: str, state) -> str:  # noqa: ARG001
+        """Test tool that processes input."""
+        return f"Processed {x}"
+
+    return test_env
+
+
+@pytest.fixture
+def async_env():
+    @fenv.start()
+    async def test_env(param: str):
+        await asyncio.sleep(0.1)
+        return f"Async Test {param}", {"param": param}
+
+    @test_env.tool()
+    async def test_tool(x: str, state) -> str:  # noqa: ARG001
+        """Test tool that processes input."""
+        await asyncio.sleep(0.1)
+        return f"Async Processed {x}"
+
+    return test_env
+
+
+def test_environment_creation(basic_env):
+    env = basic_env("test")
+    assert isinstance(env, FunctionalEnvironment)
+    assert len(env.tools) == 1
+    assert env.tools[0].info.name == "test_tool"
+
+
+@pytest.mark.asyncio
+async def test_sync_env_reset(basic_env):
+    env = basic_env("test_param")
+    obs, tools = await env.reset()
+
+    assert len(obs) == 1
+    assert obs[0].content == "Test test_param"
+    assert obs[0].role == "user"
+    assert len(tools) == 1
+
+
+@pytest.mark.asyncio
+async def test_async_env_reset(async_env):
+    env = async_env("test_param")
+    obs, tools = await env.reset()
+
+    assert len(obs) == 1
+    assert obs[0].content == "Async Test test_param"
+    assert obs[0].role == "user"
+    assert len(tools) == 1
+
+
+# Test State Management
+@pytest.mark.asyncio
+async def test_state_management():
+    @fenv.start()
+    def test_env():
+        return "Test", {"custom_value": 42}
+
+    @test_env.tool()
+    def modify_state(state) -> None:
+        """Modify the state."""
+        state.reward = 1.0
+        state.done = True
+        state.extras["new_value"] = 100
+
+    env = test_env()
+    await env.reset()
+
+    assert env.state.reward == 0
+    assert env.state.done is False
+    assert env.state.extras["custom_value"] == 42
+
+    tool_call = ToolCall.from_name("modify_state")
+    action = ToolRequestMessage(tool_calls=[tool_call])
+    msgs, reward, done, truncated = await env.step(action)
+
+    assert reward == 1.0
+    assert done is True
+    assert env.state.extras["new_value"] == 100
+
+
+@pytest.mark.asyncio
+async def test_invalid_start_function():
+    @fenv.start()
+    def invalid_env():
+        return "Only one value"  # Should return tuple
+
+    env = invalid_env()
+    with pytest.raises(TypeError):
+        await env.reset()
+
+
+async def test_invalid_state_dict():
+    @fenv.start()
+    def invalid_env():
+        return "Test", "not_a_dict"  # Should be a dict
+
+    env = invalid_env()
+    with pytest.raises(TypeError):
+        await env.reset()
+
+
+@pytest.mark.asyncio
+async def test_tool_execution(basic_env):
+    env = basic_env("test")
+    await env.reset()
+
+    tool_call = ToolCall.from_name("test_tool", x="data")
+    action = ToolRequestMessage(tool_calls=[tool_call])
+    msgs, reward, done, truncated = await env.step(action)
+    assert len(msgs) == 1
+    assert msgs[0].content == "Processed data"
+
+
+@pytest.mark.asyncio
+async def test_frame_export(basic_env):
+    env = basic_env("test")
+    await env.reset()
+
+    frame = env.export_frame()
+    assert isinstance(frame.state, dict)
+    assert isinstance(frame.info, dict)
+    assert "tool_names" in frame.info
+    assert frame.info["tool_names"] == ["test_tool"]
+    assert frame.info["num_tools"] == 1
+
+
+@pytest.mark.asyncio
+async def test_state_attribute_access():
+    @fenv.start()
+    def test_env():
+        return "Test", {"custom_attr": "value"}
+
+    @test_env.tool()
+    def access_state(state) -> str:
+        """Access a custom attribute."""
+        return state.custom_attr
+
+    env = test_env()
+    await env.reset()
+
+    tool_call = ToolCall.from_name("access_state")
+    action = ToolRequestMessage(tool_calls=[tool_call])
+    msgs, _, _, _ = await env.step(action)
+    assert msgs[0].content == "value"
+
+
+@pytest.mark.asyncio
+async def test_environment_reuse(basic_env):
+    env1 = basic_env("test1")
+    env2 = basic_env("test2")
+
+    obs1, _ = await env1.reset()
+    obs2, _ = await env2.reset()
+
+    assert obs1[0].content == "Test test1"
+    assert obs2[0].content == "Test test2"
+    assert env1.state.extras["param"] == "test1"
+    assert env2.state.extras["param"] == "test2"

--- a/uv.lock
+++ b/uv.lock
@@ -728,7 +728,7 @@ wheels = [
 
 [[package]]
 name = "fhaviary"
-version = "0.8.3.dev45+g78510ed.d20241202"
+version = "0.8.3.dev47+gceff482.d20241202"
 source = { editable = "." }
 dependencies = [
     { name = "docstring-parser" },
@@ -748,6 +748,7 @@ dev = [
     { name = "cloudpickle" },
     { name = "dicttoxml" },
     { name = "fastapi" },
+    { name = "httpx" },
     { name = "ipython" },
     { name = "litellm", version = "1.48.10", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.13'" },
     { name = "litellm", version = "1.52.16", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.13'" },
@@ -812,6 +813,7 @@ codeflash = [
     { name = "codeflash" },
     { name = "dicttoxml" },
     { name = "fastapi" },
+    { name = "httpx" },
     { name = "ipython" },
     { name = "litellm", version = "1.48.10", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.13'" },
     { name = "litellm", version = "1.52.16", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.13'" },
@@ -881,6 +883,7 @@ requires-dist = [
     { name = "fastapi", marker = "extra == 'server'" },
     { name = "fhaviary", extras = ["image", "llm", "server", "typing", "xml"], marker = "extra == 'dev'", editable = "." },
     { name = "httpx" },
+    { name = "httpx", marker = "extra == 'dev'", specifier = "<0.28" },
     { name = "ipython", marker = "extra == 'dev'", specifier = ">=8" },
     { name = "litellm", marker = "python_full_version >= '3.13' and extra == 'llm'", specifier = ">=1.49.1" },
     { name = "litellm", marker = "python_full_version < '3.13' and extra == 'llm'" },
@@ -911,10 +914,7 @@ codeflash = [
     { name = "codeflash", specifier = ">=0.7" },
     { name = "fhaviary", extras = ["dev"], editable = "." },
 ]
-dev = [
-    { name = "fhaviary", extras = ["dev"], editable = "." },
-    { name = "httpx", specifier = "<0.28" },
-]
+dev = [{ name = "fhaviary", extras = ["dev"], editable = "." }]
 
 [[package]]
 name = "filelock"

--- a/uv.lock
+++ b/uv.lock
@@ -180,7 +180,7 @@ wheels = [
 
 [[package]]
 name = "aviary-gsm8k"
-version = "0.10.1.dev5+gd171edd"
+version = "0.8.3.dev25+g2d8dd7b"
 source = { editable = "packages/gsm8k" }
 dependencies = [
     { name = "datasets" },
@@ -203,7 +203,7 @@ requires-dist = [
 
 [[package]]
 name = "aviary-hotpotqa"
-version = "0.10.1.dev5+gd171edd"
+version = "0.8.3.dev25+g2d8dd7b"
 source = { editable = "packages/hotpotqa" }
 dependencies = [
     { name = "beautifulsoup4" },
@@ -536,12 +536,12 @@ name = "coredis"
 version = "4.17.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "async-timeout" },
-    { name = "deprecated" },
-    { name = "packaging" },
-    { name = "pympler" },
-    { name = "typing-extensions" },
-    { name = "wrapt" },
+    { name = "async-timeout", marker = "python_full_version < '3.13'" },
+    { name = "deprecated", marker = "python_full_version < '3.13'" },
+    { name = "packaging", marker = "python_full_version < '3.13'" },
+    { name = "pympler", marker = "python_full_version < '3.13'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+    { name = "wrapt", marker = "python_full_version < '3.13'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/ef/0c/0f2fb1cedd224666ef08e898447bb9cf4d1e98a86b03119f1c6513093ddc/coredis-4.17.0.tar.gz", hash = "sha256:04e9976e71a42004dfe19a862c648b4047bf813e15184cddfd3cb37eb704b83f", size = 243157 }
 wheels = [
@@ -606,7 +606,7 @@ name = "deprecated"
 version = "1.2.15"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "wrapt" },
+    { name = "wrapt", marker = "python_full_version < '3.13'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/2e/a3/53e7d78a6850ffdd394d7048a31a6f14e44900adedf190f9a165f6b69439/deprecated-1.2.15.tar.gz", hash = "sha256:683e561a90de76239796e6b6feac66b99030d2dd3fcf61ef996330f14bbb9b0d", size = 2977612 }
 wheels = [
@@ -728,7 +728,7 @@ wheels = [
 
 [[package]]
 name = "fhaviary"
-version = "0.10.1.dev5+gd171edd"
+version = "0.8.3.dev43+gd3d59be.d20241202"
 source = { editable = "." }
 dependencies = [
     { name = "docstring-parser" },
@@ -749,7 +749,8 @@ dev = [
     { name = "dicttoxml" },
     { name = "fastapi" },
     { name = "ipython" },
-    { name = "litellm" },
+    { name = "litellm", version = "1.48.10", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.13'" },
+    { name = "litellm", version = "1.52.16", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.13'" },
     { name = "mypy" },
     { name = "numpy" },
     { name = "pillow" },
@@ -779,10 +780,12 @@ image = [
     { name = "pillow" },
 ]
 llm = [
-    { name = "litellm" },
+    { name = "litellm", version = "1.48.10", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.13'" },
+    { name = "litellm", version = "1.52.16", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.13'" },
 ]
 paperqa = [
-    { name = "paper-qa", extra = ["ldp"] },
+    { name = "paper-qa", version = "5.0.7", source = { registry = "https://pypi.org/simple" }, extra = ["ldp"], marker = "python_full_version >= '3.13'" },
+    { name = "paper-qa", version = "5.3.4", source = { registry = "https://pypi.org/simple" }, extra = ["ldp"], marker = "python_full_version < '3.13'" },
 ]
 server = [
     { name = "click" },
@@ -810,7 +813,8 @@ codeflash = [
     { name = "dicttoxml" },
     { name = "fastapi" },
     { name = "ipython" },
-    { name = "litellm" },
+    { name = "litellm", version = "1.48.10", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.13'" },
+    { name = "litellm", version = "1.52.16", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.13'" },
     { name = "mypy" },
     { name = "numpy" },
     { name = "pillow" },
@@ -839,7 +843,8 @@ dev = [
     { name = "dicttoxml" },
     { name = "fastapi" },
     { name = "ipython" },
-    { name = "litellm" },
+    { name = "litellm", version = "1.48.10", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.13'" },
+    { name = "litellm", version = "1.52.16", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.13'" },
     { name = "mypy" },
     { name = "numpy" },
     { name = "pillow" },
@@ -874,7 +879,7 @@ requires-dist = [
     { name = "docstring-parser", specifier = ">=0.16" },
     { name = "fastapi", marker = "extra == 'server'" },
     { name = "fhaviary", extras = ["image", "llm", "server", "typing", "xml"], marker = "extra == 'dev'", editable = "." },
-    { name = "httpx" },
+    { name = "httpx", specifier = "<0.28" },
     { name = "ipython", marker = "extra == 'dev'", specifier = ">=8" },
     { name = "litellm", marker = "python_full_version >= '3.13' and extra == 'llm'", specifier = ">=1.49.1" },
     { name = "litellm", marker = "python_full_version < '3.13' and extra == 'llm'" },
@@ -1403,7 +1408,8 @@ dependencies = [
     { name = "dm-tree" },
     { name = "fhaviary" },
     { name = "httpx" },
-    { name = "litellm" },
+    { name = "litellm", version = "1.48.10", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.13'" },
+    { name = "litellm", version = "1.52.16", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.13'" },
     { name = "networkx", extra = ["default"] },
     { name = "numpy" },
     { name = "pydantic" },
@@ -1458,10 +1464,10 @@ name = "limits"
 version = "3.13.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "deprecated" },
-    { name = "importlib-resources" },
-    { name = "packaging" },
-    { name = "typing-extensions" },
+    { name = "deprecated", marker = "python_full_version < '3.13'" },
+    { name = "importlib-resources", marker = "python_full_version < '3.13'" },
+    { name = "packaging", marker = "python_full_version < '3.13'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/c4/5f/89fb5405ee37d8b172e48e357438dd79482731b0cd5db2f734ac58f019e4/limits-3.13.0.tar.gz", hash = "sha256:6571b0c567bfa175a35fed9f8a954c0c92f1c3200804282f1b8f1de4ad98a953", size = 70218 }
 wheels = [
@@ -1470,20 +1476,52 @@ wheels = [
 
 [[package]]
 name = "litellm"
+version = "1.48.10"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version < '3.12' and platform_python_implementation == 'PyPy'",
+    "python_full_version < '3.12' and platform_python_implementation != 'PyPy'",
+    "python_full_version == '3.12.*' and platform_python_implementation == 'PyPy'",
+    "python_full_version == '3.12.*' and platform_python_implementation != 'PyPy'",
+]
+dependencies = [
+    { name = "aiohttp", marker = "python_full_version < '3.13'" },
+    { name = "click", marker = "python_full_version < '3.13'" },
+    { name = "importlib-metadata", marker = "python_full_version < '3.13'" },
+    { name = "jinja2", marker = "python_full_version < '3.13'" },
+    { name = "jsonschema", marker = "python_full_version < '3.13'" },
+    { name = "openai", version = "1.46.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.13'" },
+    { name = "pydantic", marker = "python_full_version < '3.13'" },
+    { name = "python-dotenv", marker = "python_full_version < '3.13'" },
+    { name = "requests", marker = "python_full_version < '3.13'" },
+    { name = "tiktoken", marker = "python_full_version < '3.13'" },
+    { name = "tokenizers", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8b/d7/ed47df9f2de3c1995516e309c20e750d40a0cd5f6639c11858cc3d7d0c4f/litellm-1.48.10.tar.gz", hash = "sha256:0a4ff75da78e66baeae0658ad8de498298310a5efda74c3d840ce2b013e8401d", size = 6037860 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fb/5b/b6eb2098ed289f99abb55ab966b4f318a467294c218ad846e96ba72949b0/litellm-1.48.10-py3-none-any.whl", hash = "sha256:752efd59747a0895f4695d025c66f0b2258d80a61175f7cfa41dbe4894ef95e1", size = 6238318 },
+]
+
+[[package]]
+name = "litellm"
 version = "1.52.16"
 source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.13' and platform_python_implementation == 'PyPy'",
+    "python_full_version >= '3.13' and platform_python_implementation != 'PyPy'",
+]
 dependencies = [
-    { name = "aiohttp" },
-    { name = "click" },
-    { name = "importlib-metadata" },
-    { name = "jinja2" },
-    { name = "jsonschema" },
-    { name = "openai" },
-    { name = "pydantic" },
-    { name = "python-dotenv" },
-    { name = "requests" },
-    { name = "tiktoken" },
-    { name = "tokenizers" },
+    { name = "aiohttp", marker = "python_full_version >= '3.13'" },
+    { name = "click", marker = "python_full_version >= '3.13'" },
+    { name = "importlib-metadata", marker = "python_full_version >= '3.13'" },
+    { name = "jinja2", marker = "python_full_version >= '3.13'" },
+    { name = "jsonschema", marker = "python_full_version >= '3.13'" },
+    { name = "openai", version = "1.55.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.13'" },
+    { name = "pydantic", marker = "python_full_version >= '3.13'" },
+    { name = "python-dotenv", marker = "python_full_version >= '3.13'" },
+    { name = "requests", marker = "python_full_version >= '3.13'" },
+    { name = "tiktoken", marker = "python_full_version >= '3.13'" },
+    { name = "tokenizers", marker = "python_full_version >= '3.13'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/09/2b/33ef0e18e3c6c0cb8306d3e716eb8f85e2dc3213a3e3fa77b485d237a54e/litellm-1.52.16.tar.gz", hash = "sha256:afeb60492b4790bbc23b351a5270c86ef1d063b01cc9f25fa06505c020cf789e", size = 6159209 }
 wheels = [
@@ -1885,17 +1923,46 @@ wheels = [
 
 [[package]]
 name = "openai"
+version = "1.46.1"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version < '3.12' and platform_python_implementation == 'PyPy'",
+    "python_full_version < '3.12' and platform_python_implementation != 'PyPy'",
+    "python_full_version == '3.12.*' and platform_python_implementation == 'PyPy'",
+    "python_full_version == '3.12.*' and platform_python_implementation != 'PyPy'",
+]
+dependencies = [
+    { name = "anyio", marker = "python_full_version < '3.13'" },
+    { name = "distro", marker = "python_full_version < '3.13'" },
+    { name = "httpx", marker = "python_full_version < '3.13'" },
+    { name = "jiter", marker = "python_full_version < '3.13'" },
+    { name = "pydantic", marker = "python_full_version < '3.13'" },
+    { name = "sniffio", marker = "python_full_version < '3.13'" },
+    { name = "tqdm", marker = "python_full_version < '3.13'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/fc/6b/470673304605c4aa4ee899dbab6ea12f6a0844e3ee7970ce7ecae0c89aea/openai-1.46.1.tar.gz", hash = "sha256:e5cf7f268bf516de23686d496c9dae7f0dcdcd0e87af4d288deeab8329fcbbaf", size = 297547 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/da/14/aabc614d8c446cb32043ed397dd8536a8f4c43a92c6609c05a958be9b960/openai-1.46.1-py3-none-any.whl", hash = "sha256:7517f07117cf66012bbc55c49fd6b983eaac0f3d2a09c90cba1140d4455e4290", size = 375150 },
+]
+
+[[package]]
+name = "openai"
 version = "1.55.1"
 source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.13' and platform_python_implementation == 'PyPy'",
+    "python_full_version >= '3.13' and platform_python_implementation != 'PyPy'",
+]
 dependencies = [
-    { name = "anyio" },
-    { name = "distro" },
-    { name = "httpx" },
-    { name = "jiter" },
-    { name = "pydantic" },
-    { name = "sniffio" },
-    { name = "tqdm" },
-    { name = "typing-extensions" },
+    { name = "anyio", marker = "python_full_version >= '3.13'" },
+    { name = "distro", marker = "python_full_version >= '3.13'" },
+    { name = "httpx", marker = "python_full_version >= '3.13'" },
+    { name = "jiter", marker = "python_full_version >= '3.13'" },
+    { name = "pydantic", marker = "python_full_version >= '3.13'" },
+    { name = "sniffio", marker = "python_full_version >= '3.13'" },
+    { name = "tqdm", marker = "python_full_version >= '3.13'" },
+    { name = "typing-extensions", marker = "python_full_version >= '3.13'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/c2/5c/8c126c0c4ceddf63964acd224c3cf5a37c2e845bb8ff12db6acc96d335c5/openai-1.55.1.tar.gz", hash = "sha256:471324321e7739214f16a544e801947a046d3c5d516fae8719a317234e4968d3", size = 314276 }
 wheels = [
@@ -1967,36 +2034,79 @@ wheels = [
 
 [[package]]
 name = "paper-qa"
-version = "5.5.0"
+version = "5.0.7"
 source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "aiohttp" },
-    { name = "anyio" },
-    { name = "coredis" },
-    { name = "fhaviary", extra = ["llm"] },
-    { name = "html2text" },
-    { name = "httpx" },
-    { name = "limits" },
-    { name = "litellm" },
-    { name = "numpy" },
-    { name = "pybtex" },
-    { name = "pydantic" },
-    { name = "pydantic-settings" },
-    { name = "pymupdf" },
-    { name = "rich" },
-    { name = "setuptools" },
-    { name = "tantivy" },
-    { name = "tenacity" },
-    { name = "tiktoken" },
+resolution-markers = [
+    "python_full_version >= '3.13' and platform_python_implementation == 'PyPy'",
+    "python_full_version >= '3.13' and platform_python_implementation != 'PyPy'",
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c1/8e/3cb53575b288259b0678991a3d16c3d2d03bd03e5519a1fe3ab2e7e7af01/paper_qa-5.5.0.tar.gz", hash = "sha256:fe9658c3238be95bfe49927efaf4ebec7aa3a5e0917b34418942f2d9fb12f44f", size = 3133159 }
+dependencies = [
+    { name = "aiohttp", marker = "python_full_version >= '3.13'" },
+    { name = "anyio", marker = "python_full_version >= '3.13'" },
+    { name = "fhaviary", extra = ["llm"], marker = "python_full_version >= '3.13'" },
+    { name = "html2text", marker = "python_full_version >= '3.13'" },
+    { name = "httpx", marker = "python_full_version >= '3.13'" },
+    { name = "litellm", version = "1.52.16", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.13'" },
+    { name = "numpy", marker = "python_full_version >= '3.13'" },
+    { name = "pybtex", marker = "python_full_version >= '3.13'" },
+    { name = "pydantic", marker = "python_full_version >= '3.13'" },
+    { name = "pydantic-settings", version = "2.6.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.13'" },
+    { name = "pymupdf", marker = "python_full_version >= '3.13'" },
+    { name = "rich", marker = "python_full_version >= '3.13'" },
+    { name = "setuptools", marker = "python_full_version >= '3.13'" },
+    { name = "tantivy", marker = "python_full_version >= '3.13'" },
+    { name = "tenacity", marker = "python_full_version >= '3.13'" },
+    { name = "tiktoken", marker = "python_full_version >= '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/05/df/2631e79895cea99e56335e8b7e2e074d0ed0bd2d0794db6f525dd04b39a8/paper_qa-5.0.7.tar.gz", hash = "sha256:c7ed06343bbe3ccd6b13b9b93d0deaedcfaf0a814402ccca761e2f933c8e6b37", size = 2563086 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/11/a7/aa80a5b6c997dd6b70d95e5d18595799d91cdbaf2838dd8fb0ea654b609d/paper_qa-5.5.0-py3-none-any.whl", hash = "sha256:2c94bdcd8ac21f68a34eb577d2c3806c7038c9d418fc69651706be093a8f7138", size = 527984 },
+    { url = "https://files.pythonhosted.org/packages/51/e1/5e79599474d2c448ffb6ce22157016426a92d033d94cb2490310ee341fb5/paper_qa-5.0.7-py3-none-any.whl", hash = "sha256:a39f239cba526a7c5f80fc36820036e4c09c4e3b011cda6aa235b1bee04fbd2e", size = 500296 },
 ]
 
 [package.optional-dependencies]
 ldp = [
-    { name = "ldp" },
+    { name = "ldp", marker = "python_full_version >= '3.13'" },
+]
+
+[[package]]
+name = "paper-qa"
+version = "5.3.4"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version < '3.12' and platform_python_implementation == 'PyPy'",
+    "python_full_version < '3.12' and platform_python_implementation != 'PyPy'",
+    "python_full_version == '3.12.*' and platform_python_implementation == 'PyPy'",
+    "python_full_version == '3.12.*' and platform_python_implementation != 'PyPy'",
+]
+dependencies = [
+    { name = "aiohttp", marker = "python_full_version < '3.13'" },
+    { name = "anyio", marker = "python_full_version < '3.13'" },
+    { name = "coredis", marker = "python_full_version < '3.13'" },
+    { name = "fhaviary", extra = ["llm"], marker = "python_full_version < '3.13'" },
+    { name = "html2text", marker = "python_full_version < '3.13'" },
+    { name = "httpx", marker = "python_full_version < '3.13'" },
+    { name = "limits", marker = "python_full_version < '3.13'" },
+    { name = "litellm", version = "1.48.10", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.13'" },
+    { name = "numpy", marker = "python_full_version < '3.13'" },
+    { name = "openai", version = "1.46.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.13'" },
+    { name = "pybtex", marker = "python_full_version < '3.13'" },
+    { name = "pydantic", marker = "python_full_version < '3.13'" },
+    { name = "pydantic-settings", version = "2.5.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.13'" },
+    { name = "pymupdf", marker = "python_full_version < '3.13'" },
+    { name = "rich", marker = "python_full_version < '3.13'" },
+    { name = "setuptools", marker = "python_full_version < '3.13'" },
+    { name = "tantivy", marker = "python_full_version < '3.13'" },
+    { name = "tenacity", marker = "python_full_version < '3.13'" },
+    { name = "tiktoken", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f4/94/01aba99c1e3b4c97f7654efeebf334baab9510035960be792e9bf3c07a88/paper_qa-5.3.4.tar.gz", hash = "sha256:8b6edcdc490fe43d2871ff924285be89ecbf43f552b22b367f81738c412e37b5", size = 2962068 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5f/f9/f7ac5f5f091792f28c15cb5bbe127b5c50b42a99af14f164c6096a4f2b80/paper_qa-5.3.4-py3-none-any.whl", hash = "sha256:88cf43d4410558c8b583fc8e4dbda0158bf5f3b7732b57ce50561ba7373de51e", size = 524664 },
+]
+
+[package.optional-dependencies]
+ldp = [
+    { name = "ldp", marker = "python_full_version < '3.13'" },
 ]
 
 [[package]]
@@ -2342,11 +2452,34 @@ wheels = [
 
 [[package]]
 name = "pydantic-settings"
+version = "2.5.2"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version < '3.12' and platform_python_implementation == 'PyPy'",
+    "python_full_version < '3.12' and platform_python_implementation != 'PyPy'",
+    "python_full_version == '3.12.*' and platform_python_implementation == 'PyPy'",
+    "python_full_version == '3.12.*' and platform_python_implementation != 'PyPy'",
+]
+dependencies = [
+    { name = "pydantic", marker = "python_full_version < '3.13'" },
+    { name = "python-dotenv", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/68/27/0bed9dd26b93328b60a1402febc780e7be72b42847fa8b5c94b7d0aeb6d1/pydantic_settings-2.5.2.tar.gz", hash = "sha256:f90b139682bee4d2065273d5185d71d37ea46cfe57e1b5ae184fc6a0b2484ca0", size = 70938 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/29/8d/29e82e333f32d9e2051c10764b906c2a6cd140992910b5f49762790911ba/pydantic_settings-2.5.2-py3-none-any.whl", hash = "sha256:2c912e55fd5794a59bf8c832b9de832dcfdf4778d79ff79b708744eed499a907", size = 26864 },
+]
+
+[[package]]
+name = "pydantic-settings"
 version = "2.6.1"
 source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.13' and platform_python_implementation == 'PyPy'",
+    "python_full_version >= '3.13' and platform_python_implementation != 'PyPy'",
+]
 dependencies = [
-    { name = "pydantic" },
-    { name = "python-dotenv" },
+    { name = "pydantic", marker = "python_full_version >= '3.13'" },
+    { name = "python-dotenv", marker = "python_full_version >= '3.13'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/b5/d4/9dfbe238f45ad8b168f5c96ee49a3df0598ce18a0795a983b419949ce65b/pydantic_settings-2.6.1.tar.gz", hash = "sha256:e0f92546d8a9923cb8941689abf85d6601a8c19a23e97a34b2964a2e3f813ca0", size = 75646 }
 wheels = [
@@ -2410,7 +2543,7 @@ name = "pympler"
 version = "1.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pywin32", marker = "platform_system == 'Windows'" },
+    { name = "pywin32", marker = "python_full_version < '3.13' and platform_system == 'Windows'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/dd/37/c384631908029676d8e7213dd956bb686af303a80db7afbc9be36bc49495/pympler-1.1.tar.gz", hash = "sha256:1eaa867cb8992c218430f1708fdaccda53df064144d1c5656b1e6f1ee6000424", size = 179954 }
 wheels = [

--- a/uv.lock
+++ b/uv.lock
@@ -728,7 +728,7 @@ wheels = [
 
 [[package]]
 name = "fhaviary"
-version = "0.8.3.dev43+gd3d59be.d20241202"
+version = "0.8.3.dev45+g78510ed.d20241202"
 source = { editable = "." }
 dependencies = [
     { name = "docstring-parser" },
@@ -842,6 +842,7 @@ dev = [
     { name = "cloudpickle" },
     { name = "dicttoxml" },
     { name = "fastapi" },
+    { name = "httpx" },
     { name = "ipython" },
     { name = "litellm", version = "1.48.10", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.13'" },
     { name = "litellm", version = "1.52.16", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.13'" },
@@ -879,7 +880,7 @@ requires-dist = [
     { name = "docstring-parser", specifier = ">=0.16" },
     { name = "fastapi", marker = "extra == 'server'" },
     { name = "fhaviary", extras = ["image", "llm", "server", "typing", "xml"], marker = "extra == 'dev'", editable = "." },
-    { name = "httpx", specifier = "<0.28" },
+    { name = "httpx" },
     { name = "ipython", marker = "extra == 'dev'", specifier = ">=8" },
     { name = "litellm", marker = "python_full_version >= '3.13' and extra == 'llm'", specifier = ">=1.49.1" },
     { name = "litellm", marker = "python_full_version < '3.13' and extra == 'llm'" },
@@ -910,7 +911,10 @@ codeflash = [
     { name = "codeflash", specifier = ">=0.7" },
     { name = "fhaviary", extras = ["dev"], editable = "." },
 ]
-dev = [{ name = "fhaviary", extras = ["dev"], editable = "." }]
+dev = [
+    { name = "fhaviary", extras = ["dev"], editable = "." },
+    { name = "httpx", specifier = "<0.28" },
+]
 
 [[package]]
 name = "filelock"


### PR DESCRIPTION
Per discussion on slack, new interface for defining environments:


## Functional Environments

The easiest way to create an environment is using the functional interface, which just uses functions and decorators to define environments. First, let's define what the environment looks like by defining its `start` function:

```py
from aviary import fenv


@fenv.start()
def my_env(topic):
    return f"Write a story about {topic}", {"topic": topic}
```

Note that the decorator is a call (`start()`). The `start` decorator starts the definition of an environment. The function, `my_env`, can take whatever you would like and should return a tuple containing the first observation and anything you would like to store about the state of the environment (used to persist/share things between tools). The state will always automatically have an optional `reward` and a boolean `done` that indicates if the environment is complete.

Now we can define some tools:

```py
@my_env.tool()
def multiply(x: float, y: float) -> float:
    """Multiply two numbers"""
    return x * y


@my_env.tool()
def print_story(story: str | bytes, state) -> None:
    """Print a story to user and complete task"""
    print("A story about", state.extras["topic"])
    print(story)
    state.reward = 1
    state.done = True
```

The tools will be converted into things visible for LLMs using the type hints and the variable descriptions. Thus, the type hinting can be valuable for the agent using it correctly. The docstrings are also passed to the LLM, and is the primary way (along with function name) for communicating about intended tool usage.

The way to stop an environment or set a reward is via the `state` variable as shown the second tool. If the reward is not set, it is treated as zero.

Now we can use our environment:

```python
env = my_env(topic="foo")
obs, tools = await env.reset()
```
