### PR TITLE
Fixed `codeflash`'s `formatter-cmds`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ requires = ["setuptools>=64", "setuptools_scm>=8"]
 
 [dependency-groups]
 codeflash = [
-    "codeflash>=0.7",  # Pin to keep recent
+    "codeflash>=0.8",  # Pin for --verify-setup checking formatter-cmds
     "fhaviary[dev]",
 ]
 dev = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -101,7 +101,7 @@ preview = true
 [tool.codeflash]
 disable-imports-sorting = true
 disable-telemetry = true
-formatter-cmds = ["ruff check --exit-zero --fix $file", "ruff format $file"]
+formatter-cmds = ["uv tool run ruff check --exit-zero --fix $file", "uv tool run ruff format $file"]
 module-root = "src/aviary"
 test-framework = "pytest"
 tests-root = "tests"

--- a/uv.lock
+++ b/uv.lock
@@ -177,7 +177,7 @@ wheels = [
 
 [[package]]
 name = "aviary-gsm8k"
-version = "0.11.1.dev3+g469d286"
+version = "0.11.1.dev3+gef1e2d5.d20241204"
 source = { editable = "packages/gsm8k" }
 dependencies = [
     { name = "datasets" },
@@ -200,7 +200,7 @@ requires-dist = [
 
 [[package]]
 name = "aviary-hotpotqa"
-version = "0.11.1.dev3+g469d286"
+version = "0.11.1.dev3+gef1e2d5.d20241204"
 source = { editable = "packages/hotpotqa" }
 dependencies = [
     { name = "beautifulsoup4" },
@@ -825,7 +825,7 @@ wheels = [
 
 [[package]]
 name = "fhaviary"
-version = "0.11.1.dev3+g469d286"
+version = "0.11.1.dev4+g1e8ea27.d20241204"
 source = { editable = "." }
 dependencies = [
     { name = "docstring-parser" },
@@ -899,11 +899,65 @@ xml = [
 
 [package.dev-dependencies]
 codeflash = [
+    { name = "aviary-gsm8k", extra = ["typing"] },
+    { name = "aviary-hotpotqa" },
+    { name = "boto3-stubs", extra = ["s3"] },
+    { name = "click" },
+    { name = "cloudpickle" },
     { name = "codeflash" },
-    { name = "fhaviary", extra = ["dev"] },
+    { name = "dicttoxml" },
+    { name = "fastapi" },
+    { name = "httpx" },
+    { name = "ipython" },
+    { name = "litellm" },
+    { name = "mypy" },
+    { name = "numpy" },
+    { name = "pillow" },
+    { name = "pre-commit" },
+    { name = "pydantic" },
+    { name = "pylint" },
+    { name = "pylint-pydantic" },
+    { name = "pytest" },
+    { name = "pytest-asyncio" },
+    { name = "pytest-recording" },
+    { name = "pytest-subtests" },
+    { name = "pytest-sugar" },
+    { name = "pytest-timer", extra = ["colorama"] },
+    { name = "pytest-xdist" },
+    { name = "refurb" },
+    { name = "typeguard" },
+    { name = "types-pillow" },
+    { name = "uvicorn" },
 ]
 dev = [
-    { name = "fhaviary", extra = ["dev"] },
+    { name = "aviary-gsm8k", extra = ["typing"] },
+    { name = "aviary-hotpotqa" },
+    { name = "boto3-stubs", extra = ["s3"] },
+    { name = "click" },
+    { name = "cloudpickle" },
+    { name = "dicttoxml" },
+    { name = "fastapi" },
+    { name = "httpx" },
+    { name = "ipython" },
+    { name = "litellm" },
+    { name = "mypy" },
+    { name = "numpy" },
+    { name = "pillow" },
+    { name = "pre-commit" },
+    { name = "pydantic" },
+    { name = "pylint" },
+    { name = "pylint-pydantic" },
+    { name = "pytest" },
+    { name = "pytest-asyncio" },
+    { name = "pytest-recording" },
+    { name = "pytest-subtests" },
+    { name = "pytest-sugar" },
+    { name = "pytest-timer", extra = ["colorama"] },
+    { name = "pytest-xdist" },
+    { name = "refurb" },
+    { name = "typeguard" },
+    { name = "types-pillow" },
+    { name = "uvicorn" },
 ]
 
 [package.metadata]
@@ -949,7 +1003,7 @@ requires-dist = [
 
 [package.metadata.requires-dev]
 codeflash = [
-    { name = "codeflash", specifier = ">=0.7" },
+    { name = "codeflash", specifier = ">=0.8" },
     { name = "fhaviary", extras = ["dev"], editable = "." },
 ]
 dev = [{ name = "fhaviary", extras = ["dev"], editable = "." }]


### PR DESCRIPTION
Failing `formatter-cmds` was leading to `codeflash` failing. This PR fixes the `formatter-cmds` integration