### PR TITLE
Forbid extra arguments in configuration

### DIFF
--- a/src/aviary/utils.py
+++ b/src/aviary/utils.py
@@ -9,7 +9,7 @@ from collections.abc import Sequence
 from enum import StrEnum
 from typing import TYPE_CHECKING, Any, ClassVar, Literal, Self, cast
 
-from pydantic import BaseModel, Field, model_validator
+from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 try:
     from litellm import acompletion
@@ -215,6 +215,8 @@ _CAPITAL_A_INDEX = ord("A")
 
 
 class MultipleChoiceQuestion(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
     QUESTION_PROMPT_TEMPLATE: ClassVar[str] = "Q: {question}\n\nOptions:\n{options}"
     DEFAULT_UNSURE_OPTION: ClassVar[str] = (
         "Insufficient information to answer this question"


### PR DESCRIPTION
Pydantic silently suppressing unexpected arguments is dangerous when combined with YAML configurations (no chance of mypy catching a typo) and defaults. This is the one case in aviary where we didn't already have `extra="forbid"`.