### PR TITLE
Allowing `random.Random` seed and documenting `TaskDataset` shuffling risk

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -84,7 +84,7 @@ repos:
           - fastapi
           - httpx < 0.28 # Match aviary pyproject.toml
           - litellm
-          - numpy
+          - numpy>=1 # Match aviary pyproject.toml
           - pydantic~=2.0 # Match aviary pyproject.toml
           - tenacity
           - types-Pillow

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,7 @@ dev = [
     "httpx<0.28",  # Pin until we remove app argument in clients that was deprecated in 0.28
     "ipython>=8",  # Pin to keep recent
     "mypy>=1.8",  # Pin for mutable-override
+    "numpy>=1",  # Pin to keep recent
     "pre-commit>=3.4",  # Pin to keep recent
     "pydantic~=2.9",  # Pydantic 2.9 changed JSON schema exports 'allOf', so ensure tests match
     "pylint-pydantic",

--- a/src/aviary/utils.py
+++ b/src/aviary/utils.py
@@ -7,7 +7,7 @@ import string
 from ast import literal_eval
 from collections.abc import Sequence
 from enum import StrEnum
-from typing import TYPE_CHECKING, Any, ClassVar, Literal, Self, cast
+from typing import TYPE_CHECKING, Any, ClassVar, Literal, Self, TypeVar, cast
 
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
@@ -209,6 +209,24 @@ async def extract_answer(
         if answer == option.strip().casefold():
             return option
     return None
+
+
+T = TypeVar("T")
+
+
+def shuffle(
+    value: Sequence[T], seed: "int | random.Random | np.random.Generator | None" = None
+) -> Sequence[T]:
+    """Shuffle a non-mutable sequence."""
+    # Since most shuffle fn's are in-place, we employ sampling without replacement
+    if isinstance(seed, int):
+        return random.Random(seed).sample(value, k=len(value))
+    if isinstance(seed, random.Random):
+        return seed.sample(value, k=len(value))
+    if seed is None:
+        return random.sample(value, k=len(value))
+    # Numpy RNG. Note this will have a type error for sequences like str, but oh well
+    return seed.choice(value, size=len(value), replace=False)  # type: ignore[arg-type,return-value]
 
 
 _CAPITAL_A_INDEX = ord("A")

--- a/src/aviary/utils.py
+++ b/src/aviary/utils.py
@@ -280,10 +280,11 @@ class MultipleChoiceQuestion(BaseModel):
             "Optional seed or random number generator to use in randomization of"
             " options, where seeding is not global (e.g. no `random.seed`). Optionally"
             " pass in the string literal 'SEED_USING_QUESTION' to hash the question as"
-            " the seed. If making many questions with the same amount of options in"
-            " parallel, take care to either specify a different seed per question (e.g."
-            " using 'SEED_USING_QUESTION') or specify a random number generator to"
-            " avoid placing the ideal option in the same index."
+            " the seed. If making many questions with the same count of options and"
+            " sharing a seed across all instantiations, take care to either specify a"
+            " different seed per question (e.g. using 'SEED_USING_QUESTION') or specify"
+            " a random number generator, to avoid placing the ideal option being"
+            " shuffled into the same index for every question."
         ),
     )
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -291,7 +291,7 @@ class TestLitQAEvaluation:
         )
         self._assert_prompt_is_valid(mc_question_2b, question, ideal, distractors)
         assert mc_question_2a == mc_question_2b, (
-            "Same seeding strategy should lead to same prompts"
+            "Question seeding strategy should lead to same prompts"
         )
         assert mc_question_2a != mc_question_1a, (
             "Different seeding strategies should lead to different prompts"

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,5 +1,8 @@
+import random
 from collections.abc import Iterable, Sequence
+from copy import deepcopy
 
+import numpy as np
 import pytest
 
 from aviary.core import (
@@ -8,6 +11,7 @@ from aviary.core import (
     eval_answer,
     extract_answer,
 )
+from aviary.utils import T, shuffle
 from tests.conftest import VCR_DEFAULT_MATCH_ON
 
 
@@ -77,6 +81,40 @@ async def test_extract_answer(
 async def test_eval_llm_config():
     config = {"temperature": 0.5}
     assert await eval_answer("250", "250", "What is 25 * 10?", "llm", config)
+
+
+@pytest.mark.parametrize(
+    ("sequence", "seed", "expected"),
+    [
+        pytest.param((), None, [], id="empty-sequence"),
+        pytest.param((1,), None, [1], id="single-element"),
+        pytest.param("12345", 42, ["1", "5", "3", "2", "4"], id="string"),
+        pytest.param(
+            list(range(10)),
+            random.Random(42),
+            [1, 0, 4, 9, 6, 5, 8, 2, 3, 7],
+            id="random-rng",
+        ),
+        pytest.param(
+            list(range(10)),
+            np.random.default_rng(42),
+            [2, 9, 1, 6, 3, 8, 5, 7, 4, 0],
+            id="numpy-rng",
+        ),
+    ],
+)
+def test_shuffle(
+    sequence: Sequence[T],
+    seed: int | random.Random | np.random.Generator | None,
+    expected: Sequence[T],
+) -> None:
+    deepcopy_sequence = deepcopy(sequence)
+    shuffled = shuffle(sequence, seed)
+    assert sequence == deepcopy_sequence, "Should not mutate input"
+    # Use length then element-wise comparison to work around numpy:
+    # > The truth value of an array with more than one element is ambiguous.
+    assert len(shuffled) == len(expected)
+    assert all(v == e for v, e in zip(shuffled, expected, strict=True))
 
 
 class TestLitQAEvaluation:

--- a/uv.lock
+++ b/uv.lock
@@ -178,7 +178,7 @@ wheels = [
 
 [[package]]
 name = "aviary-gsm8k"
-version = "0.14.1.dev5+g71fb9c1"
+version = "0.15.1.dev1+g6d5711d.d20250117"
 source = { editable = "packages/gsm8k" }
 dependencies = [
     { name = "datasets" },
@@ -201,7 +201,7 @@ requires-dist = [
 
 [[package]]
 name = "aviary-hotpotqa"
-version = "0.14.1.dev5+g71fb9c1"
+version = "0.15.1.dev1+g6d5711d.d20250117"
 source = { editable = "packages/hotpotqa" }
 dependencies = [
     { name = "beautifulsoup4" },
@@ -248,7 +248,7 @@ name = "blessed"
 version = "1.20.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "jinxed", marker = "sys_platform == 'win32'" },
+    { name = "jinxed", marker = "platform_system == 'Windows'" },
     { name = "six" },
     { name = "wcwidth" },
 ]
@@ -399,7 +399,7 @@ name = "click"
 version = "8.1.8"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "colorama", marker = "platform_system == 'Windows'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/b9/2e/0090cbf739cee7d23781ad4b89a9894a41538e4fcf4c31dcdd705b78eb8b/click-8.1.8.tar.gz", hash = "sha256:ed53c9d8990d83c2a27deae68e4ee337473f6330c040a31d4225c9574d16096a", size = 226593 }
 wheels = [
@@ -819,7 +819,7 @@ wheels = [
 
 [[package]]
 name = "fhaviary"
-version = "0.14.1.dev5+g71fb9c1"
+version = "0.15.1.dev1+g6d5711d.d20250117"
 source = { editable = "." }
 dependencies = [
     { name = "docstring-parser" },
@@ -894,11 +894,67 @@ xml = [
 
 [package.dev-dependencies]
 codeflash = [
+    { name = "aviary-gsm8k", extra = ["typing"] },
+    { name = "aviary-hotpotqa" },
+    { name = "boto3-stubs", extra = ["s3"] },
+    { name = "click" },
+    { name = "cloudpickle" },
     { name = "codeflash" },
-    { name = "fhaviary", extra = ["dev"] },
+    { name = "dicttoxml" },
+    { name = "fastapi" },
+    { name = "httpx" },
+    { name = "ipython" },
+    { name = "litellm" },
+    { name = "mypy" },
+    { name = "numpy" },
+    { name = "pillow" },
+    { name = "pre-commit" },
+    { name = "pydantic" },
+    { name = "pylint" },
+    { name = "pylint-pydantic" },
+    { name = "pytest" },
+    { name = "pytest-asyncio" },
+    { name = "pytest-recording" },
+    { name = "pytest-subtests" },
+    { name = "pytest-sugar" },
+    { name = "pytest-timer", extra = ["colorama"] },
+    { name = "pytest-xdist" },
+    { name = "refurb" },
+    { name = "typeguard" },
+    { name = "types-pillow" },
+    { name = "uvicorn" },
+    { name = "vcrpy" },
 ]
 dev = [
-    { name = "fhaviary", extra = ["dev"] },
+    { name = "aviary-gsm8k", extra = ["typing"] },
+    { name = "aviary-hotpotqa" },
+    { name = "boto3-stubs", extra = ["s3"] },
+    { name = "click" },
+    { name = "cloudpickle" },
+    { name = "dicttoxml" },
+    { name = "fastapi" },
+    { name = "httpx" },
+    { name = "ipython" },
+    { name = "litellm" },
+    { name = "mypy" },
+    { name = "numpy" },
+    { name = "pillow" },
+    { name = "pre-commit" },
+    { name = "pydantic" },
+    { name = "pylint" },
+    { name = "pylint-pydantic" },
+    { name = "pytest" },
+    { name = "pytest-asyncio" },
+    { name = "pytest-recording" },
+    { name = "pytest-subtests" },
+    { name = "pytest-sugar" },
+    { name = "pytest-timer", extra = ["colorama"] },
+    { name = "pytest-xdist" },
+    { name = "refurb" },
+    { name = "typeguard" },
+    { name = "types-pillow" },
+    { name = "uvicorn" },
+    { name = "vcrpy" },
 ]
 
 [package.metadata]
@@ -921,6 +977,7 @@ requires-dist = [
     { name = "litellm", marker = "python_full_version >= '3.13' and extra == 'llm'", specifier = ">=1.49.1" },
     { name = "litellm", marker = "python_full_version < '3.13' and extra == 'llm'" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.8" },
+    { name = "numpy", marker = "extra == 'dev'", specifier = ">=1" },
     { name = "numpy", marker = "extra == 'typing'" },
     { name = "paper-qa", extras = ["ldp"], marker = "extra == 'paperqa'", specifier = ">=5" },
     { name = "pillow", marker = "extra == 'image'" },
@@ -1276,7 +1333,7 @@ name = "jinxed"
 version = "1.3.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "ansicon", marker = "sys_platform == 'win32'" },
+    { name = "ansicon", marker = "platform_system == 'Windows'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/20/d0/59b2b80e7a52d255f9e0ad040d2e826342d05580c4b1d7d7747cfb8db731/jinxed-1.3.0.tar.gz", hash = "sha256:1593124b18a41b7a3da3b078471442e51dbad3d77b4d4f2b0c26ab6f7d660dbf", size = 80981 }
 wheels = [
@@ -2484,7 +2541,7 @@ name = "pympler"
 version = "1.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pywin32", marker = "sys_platform == 'win32'" },
+    { name = "pywin32", marker = "platform_system == 'Windows'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/dd/37/c384631908029676d8e7213dd956bb686af303a80db7afbc9be36bc49495/pympler-1.1.tar.gz", hash = "sha256:1eaa867cb8992c218430f1708fdaccda53df064144d1c5656b1e6f1ee6000424", size = 179954 }
 wheels = [
@@ -3200,7 +3257,7 @@ name = "tqdm"
 version = "4.67.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "colorama", marker = "platform_system == 'Windows'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/a8/4b/29b4ef32e036bb34e4ab51796dd745cdba7ed47ad142a9f4a1eb8e0c744d/tqdm-4.67.1.tar.gz", hash = "sha256:f8aef9c52c08c13a65f30ea34f4e5aac3fd1a34959879d7e59e63027286627f2", size = 169737 }
 wheels = [


### PR DESCRIPTION
@ludomitch and I realized that if you specify the same `int` seed for an entire `TaskDataset` (which we don't currently do, but _could_ do), assuming the multiple choice options are the same length, the ideal answer would show up in the same index.

This PR:
1. Documents this risk
2. Adds support for `random.Random` to `MultipleChoiceQuestion`
3. Adds a (not in-place) `shuffle` utility