### PR TITLE
Removed `arbitrary_types_allowed=True` from `MultipleChoiceQuestion` via custom Pydantic serializer/validator

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -531,6 +531,11 @@ max-line-length = 120
 # defaults when analyzing docstring sections.
 convention = "google"
 
+[tool.ruff.lint.pylint]
+allow-dunder-method-names = [
+    "__get_pydantic_core_schema__",  # Pydantic built-in: https://docs.pydantic.dev/latest/concepts/types/#customizing-validation-with-__get_pydantic_core_schema__
+]
+
 [tool.setuptools.packages.find]
 where = ["src"]
 

--- a/src/aviary/utils.py
+++ b/src/aviary/utils.py
@@ -7,7 +7,7 @@ import string
 from ast import literal_eval
 from collections.abc import Sequence
 from enum import StrEnum
-from typing import TYPE_CHECKING, Any, ClassVar, Literal, Self, TypeVar, cast
+from typing import TYPE_CHECKING, Annotated, Any, ClassVar, Literal, Self, TypeVar, cast
 
 from pydantic import BaseModel, ConfigDict, Field, GetCoreSchemaHandler, model_validator
 from pydantic_core import core_schema as cs
@@ -265,10 +265,7 @@ _CAPITAL_A_INDEX = ord("A")
 
 
 class MultipleChoiceQuestion(BaseModel):
-    model_config = ConfigDict(
-        extra="forbid",
-        arbitrary_types_allowed=True,  # Allow random.Random
-    )
+    model_config = ConfigDict(extra="forbid")
 
     OPEN_ANSWER_PROMPT_TEMPLATE: ClassVar[str] = "Q: {question}"
     MC_QUESTION_PROMPT_TEMPLATE: ClassVar[str] = "\n\n".join((
@@ -306,7 +303,12 @@ class MultipleChoiceQuestion(BaseModel):
             " automatically added."
         ),
     )
-    shuffle_seed: int | random.Random | Literal["SEED_USING_QUESTION"] | None = Field(
+    shuffle_seed: (
+        int
+        | Annotated[random.Random, RandomAnnotation()]
+        | Literal["SEED_USING_QUESTION"]
+        | None
+    ) = Field(
         default=None,
         description=(
             "Optional seed or random number generator to use in randomization of"


### PR DESCRIPTION
https://github.com/Future-House/aviary/pull/177 added `random.Random` support, but also added `arbitrary_types_allowed=True` to `MultipleChoiceQuestion`. I didn't like that `arbitrary_types_allowed`, so I tapped into Pydantic v2's [custom validator/serializer logic](https://docs.pydantic.dev/latest/concepts/types/#customizing-validation-with-__get_pydantic_core_schema__) to allow serialization of `random.Random`.