### PR TITLE
Moved `DummyEnv` to report empty `ToolRequestMessage`

### DIFF
--- a/src/aviary/env.py
+++ b/src/aviary/env.py
@@ -469,7 +469,7 @@ class DummyEnv(Environment[DummyEnvState]):
     ) -> tuple[Messages, float, bool, bool]:
         msgs: Messages = await self.exec_tool_calls(
             action, state=self.state, concurrency=self.concurrent_tool_calls
-        )
+        ) or [Message(content=f"No tool calls input in tool request {action}.")]
         self.state.messages.extend(msgs)
         return msgs, self.state.reward, self.state.done, False
 

--- a/tests/test_envs.py
+++ b/tests/test_envs.py
@@ -53,6 +53,13 @@ class TestDummyEnv:
         assert isinstance(obs, list)
         assert len(obs) == 1
 
+        # Check if we have a bad policy that gives an empty action, the env reports this
+        obs, reward, done, _ = await dummy_env.step(
+            action=ToolRequestMessage(tool_calls=[])
+        )
+        assert not done, "Should not be done after empty action"
+        assert "no tool calls" in obs[0].content.lower()
+
         action = await my_policy(obs)
         _, reward, done, _ = await dummy_env.step(action)
         assert reward > 0


### PR DESCRIPTION
Without this, we can have failures masked in our unit testing