### PR TITLE
Add question_id functionality to mcq object

### DIFF
--- a/src/aviary/utils.py
+++ b/src/aviary/utils.py
@@ -377,6 +377,7 @@ class MultipleChoiceQuestion(BaseModel):
             )
         return self.MC_QUESTION_PROMPT_TEMPLATE.format(
             question=self.question,
+            question_id=self.question_id,
             options="\n".join([
                 f"{_CAPITAL_A_INDEX + i:c}) {o}" for i, o in enumerate(self.options)
             ]),

--- a/src/aviary/utils.py
+++ b/src/aviary/utils.py
@@ -285,8 +285,8 @@ class MultipleChoiceQuestion(BaseModel):
         description="Question to answer (without multiple choice options)."
     )
 
-    question_id: str | None = Field(
-        default=None, description="Unique identifier for the question."
+    question_id: str = Field(
+        default="Q", description="Unique identifier for the question."
     )
 
     prompt_without_options: bool = Field(
@@ -373,7 +373,7 @@ class MultipleChoiceQuestion(BaseModel):
         if self.prompt_without_options:
             return self.OPEN_ANSWER_PROMPT_TEMPLATE.format(
                 question=self.question,
-                question_id="Q" if self.question_id is None else self.question_id,
+                question_id=self.question_id,
             )
         return self.MC_QUESTION_PROMPT_TEMPLATE.format(
             question=self.question,

--- a/src/aviary/utils.py
+++ b/src/aviary/utils.py
@@ -269,7 +269,7 @@ _CAPITAL_A_INDEX = ord("A")
 class MultipleChoiceQuestion(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
-    OPEN_ANSWER_PROMPT_TEMPLATE: ClassVar[str] = "Q: {question}"
+    OPEN_ANSWER_PROMPT_TEMPLATE: ClassVar[str] = "{question_id}: {question}"
     MC_QUESTION_PROMPT_TEMPLATE: ClassVar[str] = "\n\n".join((
         OPEN_ANSWER_PROMPT_TEMPLATE,
         "Options:\n{options}",

--- a/src/aviary/utils.py
+++ b/src/aviary/utils.py
@@ -284,6 +284,11 @@ class MultipleChoiceQuestion(BaseModel):
     question: str = Field(
         description="Question to answer (without multiple choice options)."
     )
+
+    question_id: str | None = Field(
+        default=None, description="Unique identifier for the question."
+    )
+
     prompt_without_options: bool = Field(
         default=False,
         description=(
@@ -348,15 +353,28 @@ class MultipleChoiceQuestion(BaseModel):
         return self.options.index(self.ideal_answer)
 
     @property
+    def ideal_answer_letter(self) -> str:
+        return chr(_CAPITAL_A_INDEX + self.ideal_answer_index)
+
+    @property
     def unsure_answer_index(self) -> int | None:
         if self.unsure_answer is None:
             return None
         return self.options.index(self.unsure_answer)
 
     @property
+    def unsure_answer_letter(self) -> str | None:
+        if self.unsure_answer_index is None:
+            return None
+        return chr(_CAPITAL_A_INDEX + self.unsure_answer_index)
+
+    @property
     def question_prompt(self) -> str:
         if self.prompt_without_options:
-            return self.OPEN_ANSWER_PROMPT_TEMPLATE.format(question=self.question)
+            return self.OPEN_ANSWER_PROMPT_TEMPLATE.format(
+                question=self.question,
+                question_id="Q" if self.question_id is None else self.question_id,
+            )
         return self.MC_QUESTION_PROMPT_TEMPLATE.format(
             question=self.question,
             options="\n".join([

--- a/src/aviary/utils.py
+++ b/src/aviary/utils.py
@@ -286,7 +286,7 @@ class MultipleChoiceQuestion(BaseModel):
     )
 
     question_id: str = Field(
-        default="Q", description="Unique identifier for the question."
+        default="Q", description="Question identifier used in the prompt."
     )
 
     prompt_without_options: bool = Field(

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -370,38 +370,85 @@ class TestLitQAEvaluation:
         )
 
     @pytest.mark.parametrize(
-        ("options", "ideal_answer", "expected_letter"),
+        ("options", "ideal_answer", "seed", "expected_letter"),
         [
-            (["A", "B", "C"], "A", "A"),
-            (["A", "B", "C"], "B", "B"),
-            (["A", "B", "C"], "C", "C"),
-            # Test when ideal answer is added to options
-            (["A", "B"], "C", "C"),
-            (["X", "Y"], "Z", "C"),
+            (
+                ["A", "B"],
+                "C",
+                42,
+                "D",
+            ),  # With seed 42, C moves to index 3 with unsure answer
+            (
+                ["X", "Y"],
+                "Z",
+                0,
+                "D",
+            ),  # With seed 0, Z stays at index 3 with unsure answer
+            # Test with ideal answer already in options
+            (
+                ["A", "B", "C"],
+                "B",
+                42,
+                "C",
+            ),  # With seed 42, B moves to index 2 with unsure answer
+            (
+                ["D", "E", "F"],
+                "E",
+                0,
+                "B",
+            ),  # With seed 0, E moves to index 1 with unsure answer
         ],
     )
     def test_ideal_answer_letter(
-        self, options: list[str], ideal_answer: str, expected_letter: str
+        self, options: list[str], ideal_answer: str, seed: int, expected_letter: str
     ) -> None:
-        """Test that ideal_answer_letter returns correct letter for answer index."""
+        """Test that ideal_answer_letter returns correct letter after shuffling."""
         mc_question = MultipleChoiceQuestion(
             question="test question",
             options=options,
             ideal_answer=ideal_answer,
-            shuffle_seed=None,  # Disable shuffling to ensure predictable ordering
+            shuffle_seed=seed,  # Use specific seeds for predictable shuffling
         )
         assert mc_question.ideal_answer_letter == expected_letter
+        # Verify the answer is actually in the shuffled options
+        assert ideal_answer in mc_question.options
 
     @pytest.mark.parametrize(
-        ("options", "ideal_answer", "unsure_answer", "expected_letter"),
+        ("options", "ideal_answer", "unsure_answer", "seed", "expected_letter"),
         [
-            (["A", "B", "C"], "A", "B", "B"),
-            (["A", "B", "C"], "A", None, None),
-            # Test when unsure answer is added to options
-            (["A", "B"], "A", "Not sure", "C"),
-            (["X", "Y"], "X", "Insufficient information", "C"),
+            # Test with custom unsure answer
+            (
+                ["A", "B"],
+                "C",
+                "Not sure",
+                42,
+                "B",
+            ),  # With seed 42, "Not sure" moves to index 1
+            (
+                ["X", "Y"],
+                "Z",
+                "Unsure",
+                0,
+                "A",
+            ),  # With seed 0, "Unsure" moves to index 0
             # Test with default unsure option
-            (["A", "B"], "A", MultipleChoiceQuestion.DEFAULT_UNSURE_OPTION, "C"),
+            (
+                ["A", "B"],
+                "C",
+                MultipleChoiceQuestion.DEFAULT_UNSURE_OPTION,
+                42,
+                "B",
+            ),
+            # Test with None unsure_answer
+            (["A", "B"], "C", None, 42, None),
+            # Test with unsure answer already in options
+            (
+                ["A", "B", "Not sure"],
+                "C",
+                "Not sure",
+                0,
+                "D",
+            ),  # With seed 0, "Not sure" moves to index 3
         ],
     )
     def test_unsure_answer_letter(
@@ -409,17 +456,22 @@ class TestLitQAEvaluation:
         options: list[str],
         ideal_answer: str,
         unsure_answer: str | None,
+        seed: int,
         expected_letter: str | None,
     ) -> None:
-        """Test that unsure_answer_letter returns correct letter for answer index."""
+        """Test that unsure_answer_letter returns correct letter after shuffling."""
         mc_question = MultipleChoiceQuestion(
             question="test question",
             options=options,
             ideal_answer=ideal_answer,
             unsure_answer=unsure_answer,
-            shuffle_seed=None,  # Disable shuffling to ensure predictable ordering
+            shuffle_seed=seed,  # Use specific seeds for predictable shuffling
         )
         assert mc_question.unsure_answer_letter == expected_letter
+        # Verify the answers are actually in the shuffled options
+        assert ideal_answer in mc_question.options
+        if unsure_answer is not None:
+            assert unsure_answer in mc_question.options
 
 
 class TestMultipleChoiceEvaluation:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -370,96 +370,47 @@ class TestLitQAEvaluation:
         )
 
     @pytest.mark.parametrize(
-        ("options", "ideal_answer", "seed", "expected_letter"),
+        (
+            "options",
+            "ideal_answer",
+            "unsure_answer",
+            "seed",
+            "expected_ideal_letter",
+            "expected_unsure_letter",
+        ),
         [
-            (
-                ["A", "B"],
-                "C",
-                42,
-                "D",
-            ),  # With seed 42, C moves to index 3 with unsure answer
-            (
-                ["X", "Y"],
-                "Z",
-                0,
-                "D",
-            ),  # With seed 0, Z stays at index 3 with unsure answer
-            # Test with ideal answer already in options
-            (
-                ["A", "B", "C"],
-                "B",
-                42,
-                "C",
-            ),  # With seed 42, B moves to index 2 with unsure answer
+            # Test cases for ideal and unsure answer letters
+            (["A", "B"], "C", "Not sure", 42, "D", "B"),  # With seed 42
+            (["X", "Y"], "Z", "Unsure", 0, "D", "A"),  # With seed 0
+            (["A", "B", "C"], "B", None, 42, "C", None),  # Ideal answer in options
             (
                 ["D", "E", "F"],
                 "E",
-                0,
-                "B",
-            ),  # With seed 0, E moves to index 1 with unsure answer
-        ],
-    )
-    def test_ideal_answer_letter(
-        self, options: list[str], ideal_answer: str, seed: int, expected_letter: str
-    ) -> None:
-        """Test that ideal_answer_letter returns correct letter after shuffling."""
-        mc_question = MultipleChoiceQuestion(
-            question="test question",
-            options=options,
-            ideal_answer=ideal_answer,
-            shuffle_seed=seed,  # Use specific seeds for predictable shuffling
-        )
-        assert mc_question.ideal_answer_letter == expected_letter
-        # Verify the answer is actually in the shuffled options
-        assert ideal_answer in mc_question.options
-
-    @pytest.mark.parametrize(
-        ("options", "ideal_answer", "unsure_answer", "seed", "expected_letter"),
-        [
-            # Test with custom unsure answer
-            (
-                ["A", "B"],
-                "C",
-                "Not sure",
-                42,
-                "B",
-            ),  # With seed 42, "Not sure" moves to index 1
-            (
-                ["X", "Y"],
-                "Z",
-                "Unsure",
-                0,
-                "A",
-            ),  # With seed 0, "Unsure" moves to index 0
-            # Test with default unsure option
-            (
-                ["A", "B"],
-                "C",
                 MultipleChoiceQuestion.DEFAULT_UNSURE_OPTION,
-                42,
+                0,
                 "B",
+                "A",
             ),
-            # Test with None unsure_answer
-            (["A", "B"], "C", None, 42, None),
-            # Test with unsure answer already in options
             (
                 ["A", "B", "Not sure"],
                 "C",
                 "Not sure",
                 0,
+                "A",
                 "D",
-            ),  # With seed 0, "Not sure" moves to index 3
+            ),  # Unsure answer in options
         ],
     )
-    def test_unsure_answer_letter(
+    def test_answer_letters(
         self,
         options: list[str],
         ideal_answer: str,
         unsure_answer: str | None,
         seed: int,
-        expected_letter: str | None,
+        expected_ideal_letter: str,
+        expected_unsure_letter: str | None,
     ) -> None:
-        """Test that unsure_answer_letter returns correct letter after shuffling."""
+        """Test that ideal_answer_letter and unsure_answer_letter return correct letters after shuffling."""
         mc_question = MultipleChoiceQuestion(
             question="test question",
             options=options,
@@ -467,9 +418,12 @@ class TestLitQAEvaluation:
             unsure_answer=unsure_answer,
             shuffle_seed=seed,  # Use specific seeds for predictable shuffling
         )
-        assert mc_question.unsure_answer_letter == expected_letter
-        # Verify the answers are actually in the shuffled options
+        # Check ideal answer letter
+        assert mc_question.ideal_answer_letter == expected_ideal_letter
         assert ideal_answer in mc_question.options
+
+        # Check unsure answer letter
+        assert mc_question.unsure_answer_letter == expected_unsure_letter
         if unsure_answer is not None:
             assert unsure_answer in mc_question.options
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -369,6 +369,58 @@ class TestLitQAEvaluation:
             "Serialization then deserialization should lead to same prompts"
         )
 
+    @pytest.mark.parametrize(
+        ("options", "ideal_answer", "expected_letter"),
+        [
+            (["A", "B", "C"], "A", "A"),
+            (["A", "B", "C"], "B", "B"),
+            (["A", "B", "C"], "C", "C"),
+            # Test when ideal answer is added to options
+            (["A", "B"], "C", "C"),
+            (["X", "Y"], "Z", "C"),
+        ],
+    )
+    def test_ideal_answer_letter(
+        self, options: list[str], ideal_answer: str, expected_letter: str
+    ) -> None:
+        """Test that ideal_answer_letter returns correct letter for answer index."""
+        mc_question = MultipleChoiceQuestion(
+            question="test question",
+            options=options,
+            ideal_answer=ideal_answer,
+            shuffle_seed=None,  # Disable shuffling to ensure predictable ordering
+        )
+        assert mc_question.ideal_answer_letter == expected_letter
+
+    @pytest.mark.parametrize(
+        ("options", "ideal_answer", "unsure_answer", "expected_letter"),
+        [
+            (["A", "B", "C"], "A", "B", "B"),
+            (["A", "B", "C"], "A", None, None),
+            # Test when unsure answer is added to options
+            (["A", "B"], "A", "Not sure", "C"),
+            (["X", "Y"], "X", "Insufficient information", "C"),
+            # Test with default unsure option
+            (["A", "B"], "A", MultipleChoiceQuestion.DEFAULT_UNSURE_OPTION, "C"),
+        ],
+    )
+    def test_unsure_answer_letter(
+        self,
+        options: list[str],
+        ideal_answer: str,
+        unsure_answer: str | None,
+        expected_letter: str | None,
+    ) -> None:
+        """Test that unsure_answer_letter returns correct letter for answer index."""
+        mc_question = MultipleChoiceQuestion(
+            question="test question",
+            options=options,
+            ideal_answer=ideal_answer,
+            unsure_answer=unsure_answer,
+            shuffle_seed=None,  # Disable shuffling to ensure predictable ordering
+        )
+        assert mc_question.unsure_answer_letter == expected_letter
+
 
 class TestMultipleChoiceEvaluation:
     @pytest.mark.parametrize(


### PR DESCRIPTION
In the DataAnalysisEnv we ask the agent to solve multiple MCQs at the same time so it's useful for each MCQ to have a unique id (eg Q1, Q2, Q3 etc)