### PR TITLE
Allowing null `FunctionInfo.parameters` to support `gemini-1.5-flash` agents

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -178,6 +178,7 @@ module = [
     "cloudpickle",  # SEE: https://github.com/cloudpipe/cloudpickle/issues/541
     "datasets",  # SEE: https://github.com/huggingface/datasets/issues/3841
     "dicttoxml",  # SEE: https://github.com/quandyfactory/dicttoxml/issues/106
+    "vcr.*",  # SEE: https://github.com/kevin1024/vcrpy/issues/780
 ]
 
 [tool.pylint]

--- a/src/aviary/env.py
+++ b/src/aviary/env.py
@@ -492,10 +492,15 @@ class DummyEnv(Environment[DummyEnvState]):
             """Cast the input argument x to an integer."""
             return int(x)
 
+        def get_random_int() -> int:
+            """Get a random integer in 1 to 10."""
+            return random.randint(1, 10)
+
         self.tools = [
             Tool.from_function(print_story),
             Tool.from_function(cast_float, allow_empty_param_descriptions=True),
             Tool.from_function(cast_int, allow_empty_param_descriptions=True),
+            Tool.from_function(get_random_int, allow_empty_param_descriptions=True),
         ]
         self.state = type(self).State(
             messages=[

--- a/tests/cassettes/TestParallelism.test_dummyenv_using_empty_params.yaml
+++ b/tests/cassettes/TestParallelism.test_dummyenv_using_empty_params.yaml
@@ -1,0 +1,135 @@
+interactions:
+  - request:
+      body:
+        '{"contents": [{"role": "user", "parts": [{"text": "Please get a random
+        integer."}]}], "tools": [{"function_declarations": [{"name": "print_story",
+        "description": "Print a story.", "parameters": {"type": "object", "properties":
+        {"story": {"description": "Story to print.", "type": "string"}}, "required":
+        ["story"]}}, {"name": "cast_float", "description": "Cast the input argument
+        x to a float.", "parameters": {"type": "object", "properties": {"x": {"type":
+        "string"}}, "required": ["x"]}}, {"name": "cast_int", "description": "Cast the
+        input argument x to an integer.", "parameters": {"type": "object", "properties":
+        {"x": {"type": "number"}}, "required": ["x"]}}, {"name": "get_random_int", "description":
+        "Get a random integer in 1 to 10.", "parameters": {"type": "object", "properties":
+        {}, "required": []}}]}], "toolConfig": {"functionCallingConfig": {"mode": "ANY"}},
+        "generationConfig": {}}'
+      headers:
+        accept:
+          - "*/*"
+        accept-encoding:
+          - gzip, deflate
+        connection:
+          - keep-alive
+        content-length:
+          - "897"
+        content-type:
+          - application/json
+        host:
+          - generativelanguage.googleapis.com
+        user-agent:
+          - litellm/1.61.1
+      method: POST
+      uri: https://generativelanguage.googleapis.com/v1beta/models/gemini-1.5-flash:generateContent?key=%3CFILTERED%3E
+    response:
+      body:
+        string: !!binary |
+          H4sIAAAAAAAC/y2OuwrCQBBF+3zFsKVoCGhl5yNIxAeI2qhITK4PSHbWnUkRxH93Rbt7Lqc4r4jI
+          wHv2ZkivAAELLhFokCTd31FDJL99P9OhGSx8rpiwVVjd4NlANFbmSg7JKb42ttAH23OJosqDGbYc
+          +qfYBaih8BI7zw5eH5AhyZ2bqqQLyLLtoXba0pU9rcfzdLIlbR2O1vxLRHNt5BuSrfajRTY9jzaz
+          3TJdbU0Q3tE7+gBFuOVc0QAAAA==
+      headers:
+        Alt-Svc:
+          - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
+        Content-Encoding:
+          - gzip
+        Content-Type:
+          - application/json; charset=UTF-8
+        Date:
+          - Thu, 13 Feb 2025 20:22:26 GMT
+        Server:
+          - scaffolding on HTTPServer2
+        Server-Timing:
+          - gfet4t7; dur=54
+        Transfer-Encoding:
+          - chunked
+        Vary:
+          - Origin
+          - X-Origin
+          - Referer
+        X-Content-Type-Options:
+          - nosniff
+        X-Frame-Options:
+          - SAMEORIGIN
+        X-XSS-Protection:
+          - "0"
+      status:
+        code: 400
+        message: Bad Request
+  - request:
+      body:
+        '{"contents": [{"role": "user", "parts": [{"text": "Please get a random
+        integer."}]}], "tools": [{"function_declarations": [{"name": "print_story",
+        "description": "Print a story.", "parameters": {"type": "object", "properties":
+        {"story": {"description": "Story to print.", "type": "string"}}, "required":
+        ["story"]}}, {"name": "cast_float", "description": "Cast the input argument
+        x to a float.", "parameters": {"type": "object", "properties": {"x": {"type":
+        "string"}}, "required": ["x"]}}, {"name": "cast_int", "description": "Cast the
+        input argument x to an integer.", "parameters": {"type": "object", "properties":
+        {"x": {"type": "number"}}, "required": ["x"]}}, {"name": "get_random_int", "description":
+        "Get a random integer in 1 to 10."}]}], "toolConfig": {"functionCallingConfig":
+        {"mode": "ANY"}}, "generationConfig": {}}'
+      headers:
+        accept:
+          - "*/*"
+        accept-encoding:
+          - gzip, deflate
+        connection:
+          - keep-alive
+        content-length:
+          - "829"
+        content-type:
+          - application/json
+        host:
+          - generativelanguage.googleapis.com
+        user-agent:
+          - litellm/1.61.1
+      method: POST
+      uri: https://generativelanguage.googleapis.com/v1beta/models/gemini-1.5-flash:generateContent?key=%3CFILTERED%3E
+    response:
+      body:
+        string: !!binary |
+          H4sIAAAAAAAC/61Ry2rDMBC86yuMznFwwI+m17S3lpbWlEIpYRPLjqgsGUkuFON/7/qVSOm1Phhp
+          ZndHO9ORIKBHkAUvwDJDb4MPRIKgG/8Dp6Rl0iKxQAg2oO2ldvo654wlZSuPliu5AyG85pmXUDPE
+          acXsXqO+qvccZVbXdaCrQanrPcK9Xc6fl26qlRjn16pggs54vxTQkktuTi8MjJJD2Wv+9HwWp/Bd
+          Paiq0eowaIfpOs2SNIuzONpEN2kabVkYZWQRH2Vpa6Bij8wCGgnnjSkOqRubqy8md6odjUzjScjx
+          3eOTmbbKgvA7t6s/U80danLhxuEkheuD4PZn2DG/f88dg3G+96jFI+JYef3EfxJLfC0yJzOF9ca0
+          4VMqFasxp3CzTsJSgDlR0pNfzHu3UbICAAA=
+      headers:
+        Alt-Svc:
+          - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
+        Content-Encoding:
+          - gzip
+        Content-Type:
+          - application/json; charset=UTF-8
+        Date:
+          - Thu, 13 Feb 2025 20:22:26 GMT
+        Server:
+          - scaffolding on HTTPServer2
+        Server-Timing:
+          - gfet4t7; dur=440
+        Transfer-Encoding:
+          - chunked
+        Vary:
+          - Origin
+          - X-Origin
+          - Referer
+        X-Content-Type-Options:
+          - nosniff
+        X-Frame-Options:
+          - SAMEORIGIN
+        X-XSS-Protection:
+          - "0"
+      status:
+        code: 200
+        message: OK
+version: 1

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,10 +1,15 @@
-from typing import Any
+from typing import TYPE_CHECKING, Any
+from urllib.parse import parse_qs, urlencode, urlparse
 
 import pytest
+import vcr.request
 
 from aviary.core import DummyEnv
 
 from . import CASSETTES_DIR
+
+if TYPE_CHECKING:
+    import vcr.request
 
 
 @pytest.fixture(name="dummy_env")
@@ -18,10 +23,28 @@ ANTHROPIC_API_KEY_HEADER = "x-api-key"
 VCR_DEFAULT_MATCH_ON = "method", "scheme", "host", "port", "path", "query"
 
 
+def filter_api_keys(request: "vcr.request.Request") -> "vcr.request.Request":
+    """Filter out API keys from request URI query parameters."""
+    parsed_uri = urlparse(request.uri)
+    if parsed_uri.query:  # If there's a query that may contain API keys
+        query_params = parse_qs(parsed_uri.query)
+
+        # Filter out the Google Gemini API key, if present
+        if "key" in query_params:
+            query_params["key"] = ["<FILTERED>"]
+
+        # Rebuild the URI, with filtered parameters
+        filtered_query = urlencode(query_params, doseq=True)
+        request.uri = parsed_uri._replace(query=filtered_query).geturl()
+
+    return request
+
+
 @pytest.fixture(scope="session", name="vcr_config")
 def fixture_vcr_config() -> dict[str, Any]:
     return {
         "filter_headers": [OPENAI_API_KEY_HEADER, ANTHROPIC_API_KEY_HEADER, "cookie"],
+        "before_record_request": filter_api_keys,
         "record_mode": "once",
         "match_on": ["method", "host", "path", "query"],
         "allow_playback_repeats": True,

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -463,6 +463,7 @@ PARAMETERS:
     async def test_arg_types(self) -> None:
         tool = Tool.from_function(example_fxn)
 
+        assert tool.info.parameters
         assert tool.info.parameters.properties["x"]["type"] == "integer"
         assert tool.info.parameters.properties["y"]["type"] == "string"
         assert tool.info.parameters.properties["z"]["type"] == "number"


### PR DESCRIPTION
Per https://github.com/BerriAI/litellm/issues/7634, Google `gemini-1.5-flash` can't call tools with empty `FunctionInfo.parameters.properties`. This PR adds a workaround where you manually clear out parameters with empty properties.