### PR TITLE
`git checkout` before `pre-commit`

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -26,8 +26,8 @@ jobs:
       - run: echo "UV_PROJECT_ENVIRONMENT=$(python -c "import sysconfig; print(sysconfig.get_config_var('prefix'))")" >> $GITHUB_ENV
       - run: uv python pin ${{ matrix.python-version }} # uv requires .python-version to match OS Python: https://github.com/astral-sh/uv/issues/11389
       - run: uv sync --python-preference only-system
+      - run: git checkout .python-version # For clean git diff given `pre-commit run --show-diff-on-failure`
       - uses: pre-commit/action@v3.0.1
-      - run: git checkout .python-version
       - uses: pre-commit-ci/lite-action@v1.1.0
         if: always()
   lint:


### PR DESCRIPTION
This prevents the printed failure by `pre-commit`'s `--show-diff-on-failure` showing the `.python-version` file changes.