### PR TITLE
`LitQATaskDataset` also storing LitQA question ID

### DIFF
--- a/packages/litqa/src/aviary/envs/litqa/task.py
+++ b/packages/litqa/src/aviary/envs/litqa/task.py
@@ -5,6 +5,7 @@ from abc import ABC
 from collections.abc import Iterable, Mapping, Sequence
 from enum import StrEnum
 from typing import TYPE_CHECKING, Any, assert_never, cast
+from uuid import UUID
 
 from ldp.alg import (
     Callback,
@@ -254,10 +255,12 @@ class LitQATaskDataset(
         self,
         ideal_answer: str,
         distractors: str | list[str],
+        question_id: str | UUID,
         question: str,
         sources: str | list[str] | None = None,
     ) -> GradablePaperQAEnvironment:
         mc_question = MultipleChoiceQuestion(
+            question_id=question_id,
             question=question,
             options=(
                 distractors
@@ -265,6 +268,7 @@ class LitQATaskDataset(
                 else MultipleChoiceQuestion.split_options(distractors)
             ),
             ideal_answer=ideal_answer,
+            prompt_without_id=True,
             **(self._question_kwargs or {}),
         )
         return GradablePaperQAEnvironment(
@@ -385,6 +389,7 @@ class LitQAv2TaskDataset(LitQATaskDataset):
         return self._make_gradable_environment(
             ideal_answer=self.data.iloc[idx].ideal,
             distractors=self.data.iloc[idx].distractors,
+            question_id=UUID(self.data.iloc[idx].id),
             question=self.data.iloc[idx].question,
             sources=sources,
         )

--- a/packages/litqa/tests/test_litqa_env.py
+++ b/packages/litqa/tests/test_litqa_env.py
@@ -109,7 +109,7 @@ class StubLitQADataset(LitQATaskDataset):
             (
                 "Politician",
                 ["Technologist", "Plumber"],
-                str(uuid4()),
+                str(uuid4()),  # Emulate how datasets.load_dataset works, it gives a str
                 "Who is Frederick Bates?",
                 "bates.txt",
             ),

--- a/src/aviary/utils.py
+++ b/src/aviary/utils.py
@@ -290,6 +290,13 @@ class MultipleChoiceQuestion(BaseModel):
         default="Q", description="Question identifier used in the prompt."
     )
 
+    prompt_without_id: bool = Field(
+        default=False,
+        description=(
+            "Opt-in flag to exclude question_id from the question_prompt,"
+            " if worried about the model memorizing question IDs."
+        ),
+    )
     prompt_without_options: bool = Field(
         default=False,
         description=(
@@ -371,17 +378,21 @@ class MultipleChoiceQuestion(BaseModel):
 
     @property
     def question_prompt(self) -> str:
+        template_vars = {
+            "question": self.question,
+            "question_id": (
+                type(self).model_fields["question_id"].default
+                if self.prompt_without_id
+                else str(self.question_id)
+            ),
+        }
         if self.prompt_without_options:
-            return self.OPEN_ANSWER_PROMPT_TEMPLATE.format(
-                question=self.question,
-                question_id=str(self.question_id),
-            )
+            return self.OPEN_ANSWER_PROMPT_TEMPLATE.format(**template_vars)
         return self.MC_QUESTION_PROMPT_TEMPLATE.format(
-            question=self.question,
-            question_id=str(self.question_id),
             options="\n".join([
                 f"{_CAPITAL_A_INDEX + i:c}) {o}" for i, o in enumerate(self.options)
             ]),
+            **template_vars,
         )
 
     @staticmethod

--- a/src/aviary/utils.py
+++ b/src/aviary/utils.py
@@ -383,7 +383,7 @@ class MultipleChoiceQuestion(BaseModel):
             "question_id": (
                 type(self).model_fields["question_id"].default
                 if self.prompt_without_id
-                else str(self.question_id)
+                else self.question_id
             ),
         }
         if self.prompt_without_options:

--- a/src/aviary/utils.py
+++ b/src/aviary/utils.py
@@ -8,6 +8,7 @@ from ast import literal_eval
 from collections.abc import Sequence
 from enum import StrEnum
 from typing import TYPE_CHECKING, Annotated, Any, ClassVar, Literal, Self, TypeVar, cast
+from uuid import UUID
 
 from pydantic import BaseModel, ConfigDict, Field, GetCoreSchemaHandler, model_validator
 from pydantic_core import core_schema as cs
@@ -285,7 +286,7 @@ class MultipleChoiceQuestion(BaseModel):
         description="Question to answer (without multiple choice options)."
     )
 
-    question_id: str = Field(
+    question_id: str | UUID = Field(
         default="Q", description="Question identifier used in the prompt."
     )
 
@@ -373,11 +374,11 @@ class MultipleChoiceQuestion(BaseModel):
         if self.prompt_without_options:
             return self.OPEN_ANSWER_PROMPT_TEMPLATE.format(
                 question=self.question,
-                question_id=self.question_id,
+                question_id=str(self.question_id),
             )
         return self.MC_QUESTION_PROMPT_TEMPLATE.format(
             question=self.question,
-            question_id=self.question_id,
+            question_id=str(self.question_id),
             options="\n".join([
                 f"{_CAPITAL_A_INDEX + i:c}) {o}" for i, o in enumerate(self.options)
             ]),


### PR DESCRIPTION
- Allowing `MultipleChoiceQuestion` to hold a question ID but not put it into the `question_prompt` via a flag `prompt_without_id`
- Moved `LitQATaskDataset` to store the question ID too