### PR TITLE
Removed relative path in `test_lfrqa_env.py`

### DIFF
--- a/packages/lfrqa/tests/test_lfrqa_env.py
+++ b/packages/lfrqa/tests/test_lfrqa_env.py
@@ -1,17 +1,20 @@
-import os
+import pathlib
 
 import pandas as pd
 
 from aviary.envs.lfrqa.env import LFRQAPairwiseEvalEnv, LFRQAQuestion
 from aviary.envs.lfrqa.task import LFRQATaskDataset
 
+TESTS_DIR = pathlib.Path(__file__).parent
+STUB_DATA_DIR = TESTS_DIR / "stub_data"
+
 
 def test_env_construction() -> None:
     data: list[LFRQAQuestion] = [
         LFRQAQuestion(**row)  # type: ignore[misc]
-        for row in pd.read_csv(
-            os.path.join("packages", "lfrqa", "tests", "stub_data", "mini_lfrqa.csv")
-        )[["qid", "question", "answer", "gold_doc_ids"]].to_dict(orient="records")
+        for row in pd.read_csv(STUB_DATA_DIR / "mini_lfrqa.csv")[
+            ["qid", "question", "answer", "gold_doc_ids"]
+        ].to_dict(orient="records")
     ]
 
     dataset = LFRQATaskDataset(data=data)


### PR DESCRIPTION
Depending on where you invoke Python, this relative path was breaking