### PR TITLE
Added question info to `HotPotQAEnv.export_frame`

### DIFF
--- a/packages/hotpotqa/src/aviary/envs/hotpotqa/env.py
+++ b/packages/hotpotqa/src/aviary/envs/hotpotqa/env.py
@@ -351,6 +351,8 @@ class HotPotQAEnv(Environment[HotPotQAEnvState]):
         """
         return Frame(
             info={
+                "question_id": self.question_id,
+                "question": self.question,
                 "steps": self.state.steps,
                 "done": self.state.done,
                 "reward": self.state.reward,


### PR DESCRIPTION
The below two HotPotQA validation set questions:

- What occupation do Chris Menges and Aram Avakian share?
- Both Ralph Bakshi and Béla Gaál had what roll in film making?
    - Nice to see HotPotQA questions can have typos in them, lol

Can lead to the same `Frame.info`:

```python
{'steps': 1, 'done': True, 'reward': 1.0, 'answer': 'They both served as film directors.'}
```

This PR ensures the `info` remains unique, by propagating question metadata.