### PR TITLE
Updated repo badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,10 @@
 # aviary
 
-![PyPI Version](https://img.shields.io/pypi/v/fhaviary)
-![PyPI Python Versions](https://img.shields.io/pypi/pyversions/fhaviary)
+[![GitHub](https://img.shields.io/badge/github-%23121011.svg?style=for-the-badge&logo=github&logoColor=white)](https://github.com/Future-House/aviary)
+[![PyPI version](https://badge.fury.io/py/fhaviary.svg)](https://badge.fury.io/py/fhaviary)
+[![tests](https://github.com/Future-House/aviary/actions/workflows/tests.yml/badge.svg)](https://github.com/Future-House/aviary)
 ![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)
-![Tests](https://github.com/Future-House/aviary/actions/workflows/tests.yml/badge.svg)
+![PyPI Python Versions](https://img.shields.io/pypi/pyversions/fhaviary)
 
 Gymnasium framework for training language model agents on constructive tasks.
 


### PR DESCRIPTION
Our public repos follow different badge patterns. It became more evident with the cookbook. 
Now that we are linking the platform documentation to the platform and plan to release it, the cookbook will see more traffic. This PR (together with similar ones on other repos) fixes it.