### PR TITLE
Removed unnecessary `pytest_asyncio.fixture`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,7 +54,7 @@ dev = [
     "pydantic~=2.9",  # Pydantic 2.9 changed JSON schema exports 'allOf', so ensure tests match
     "pylint-pydantic",
     "pylint>=3.3.3",  # Pin for Python>=3.13.1's 'collections.abc' import error
-    "pytest-asyncio<0.26",  # Down pin for https://github.com/pytest-dev/pytest-asyncio/issues/1090
+    "pytest-asyncio",
     "pytest-recording",
     "pytest-subtests",
     "pytest-sugar",

--- a/tests/test_envs.py
+++ b/tests/test_envs.py
@@ -9,7 +9,6 @@ from typing import ClassVar
 
 import litellm
 import pytest
-import pytest_asyncio
 from httpx import AsyncClient
 from pydantic import BaseModel
 from pytest_subtests import SubTests
@@ -541,7 +540,7 @@ class TestParallelism:
         ]
 
 
-@pytest_asyncio.fixture(scope="function")
+@pytest.fixture
 def server_async_client() -> AsyncClient:
     dataset = TaskDataset.from_name("dummy")
     server = TaskDatasetServer[DummyEnv](dataset)

--- a/uv.lock
+++ b/uv.lock
@@ -1000,7 +1000,7 @@ requires-dist = [
     { name = "pylint", marker = "extra == 'dev'", specifier = ">=3.3.3" },
     { name = "pylint-pydantic", marker = "extra == 'dev'" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8" },
-    { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = "<0.26" },
+    { name = "pytest-asyncio", marker = "extra == 'dev'" },
     { name = "pytest-recording", marker = "extra == 'dev'" },
     { name = "pytest-subtests", marker = "extra == 'dev'" },
     { name = "pytest-sugar", marker = "extra == 'dev'" },
@@ -2667,14 +2667,14 @@ wheels = [
 
 [[package]]
 name = "pytest-asyncio"
-version = "0.25.3"
+version = "0.26.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pytest" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/f2/a8/ecbc8ede70921dd2f544ab1cadd3ff3bf842af27f87bbdea774c7baa1d38/pytest_asyncio-0.25.3.tar.gz", hash = "sha256:fc1da2cf9f125ada7e710b4ddad05518d4cee187ae9412e9ac9271003497f07a", size = 54239 }
+sdist = { url = "https://files.pythonhosted.org/packages/8e/c4/453c52c659521066969523e87d85d54139bbd17b78f09532fb8eb8cdb58e/pytest_asyncio-0.26.0.tar.gz", hash = "sha256:c4df2a697648241ff39e7f0e4a73050b03f123f760673956cf0d72a4990e312f", size = 54156 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/67/17/3493c5624e48fd97156ebaec380dcaafee9506d7e2c46218ceebbb57d7de/pytest_asyncio-0.25.3-py3-none-any.whl", hash = "sha256:9e89518e0f9bd08928f97a3482fdc4e244df17529460bc038291ccaf8f85c7c3", size = 19467 },
+    { url = "https://files.pythonhosted.org/packages/20/7f/338843f449ace853647ace35870874f69a764d251872ed1b4de9f234822c/pytest_asyncio-0.26.0-py3-none-any.whl", hash = "sha256:7b51ed894f4fbea1340262bdae5135797ebbe21d8638978e35d31c6d19f72fb0", size = 19694 },
 ]
 
 [[package]]


### PR DESCRIPTION
https://github.com/Future-House/aviary/pull/170 removed an unnecessary `async`, and missed that it's possible to remove the `pytest_asyncio.fixture` usage too. This now allows us to pull in the latest `pytest-asyncio`.