### PR TITLE
Removed `httpx` constraint from Renovate config

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -24,10 +24,5 @@
       matchUpdateTypes: ["minor", "patch"],
       automerge: true,
     },
-    {
-      // Allow 'widen' range strategy while matching pyproject.toml
-      matchPackageNames: ["httpx"],
-      allowedVersions: "<0.28",
-    },
   ],
 }


### PR DESCRIPTION
Forgot to do this in https://github.com/Future-House/aviary/pull/225.