### PR TITLE
Giving `Agent`s insight into `ExceptionGroup`s

### DIFF
--- a/src/aviary/env.py
+++ b/src/aviary/env.py
@@ -29,7 +29,7 @@ from aviary.tools import (
     ToolRequestMessage,
     ToolResponseMessage,
 )
-from aviary.utils import is_coroutine_callable
+from aviary.utils import format_exc, is_coroutine_callable
 
 logger = logging.getLogger(__name__)
 
@@ -236,8 +236,8 @@ class Environment(ABC, Generic[TEnvState]):
                 if not handle_tool_exc:
                     raise
                 logger_msg = (
-                    f"Encountered exception during tool call for tool {tool.info.name}:"
-                    f" {exc!r}"
+                    f"Encountered exception during tool call"
+                    f" for tool {tool.info.name}: {format_exc(exc)}"
                 )
                 # logger.exception is just too verbose and clogs up console logging. This is a
                 # more human-friendly version: log a readable error message and emit the exception
@@ -247,7 +247,9 @@ class Environment(ABC, Generic[TEnvState]):
                 tool_exc = exc
             if tool_exc:
                 # No need to mention tool.info.name here, since it'll get wrapped in a ToolResponseMessage
-                s_content = f"Encountered exception during tool call: {tool_exc}"
+                s_content = (
+                    f"Encountered exception during tool call: {format_exc(tool_exc)}"
+                )
             elif isinstance(content, str):
                 s_content = content
             elif isinstance(content, BaseModel):

--- a/src/aviary/utils.py
+++ b/src/aviary/utils.py
@@ -472,7 +472,7 @@ class MultipleChoiceEvaluation(StrEnum):
         return MultipleChoiceEvaluation.INCORRECT
 
 
-def format_exc(exc: Exception) -> str:
+def format_exc(exc: BaseException) -> str:
     """Format an exception to be friendly for concise and human-readable logs."""
     if isinstance(exc, ExceptionGroup):  # Expand sub-exceptions
         return (

--- a/src/aviary/utils.py
+++ b/src/aviary/utils.py
@@ -470,3 +470,13 @@ class MultipleChoiceEvaluation(StrEnum):
         if question.unsure_answer and extracted_answer == question.unsure_answer:
             return MultipleChoiceEvaluation.UNSURE
         return MultipleChoiceEvaluation.INCORRECT
+
+
+def format_exc(exc: Exception) -> str:
+    """Format an exception to be friendly for concise and human-readable logs."""
+    if isinstance(exc, ExceptionGroup):  # Expand sub-exceptions
+        return (
+            f"{exc}, where sub-exceptions are:"
+            f" {', '.join(repr(e) for e in exc.exceptions)}"
+        )
+    return repr(exc)


### PR DESCRIPTION
Currently with an `ExceptionGroup` failure in a tool call, the emitted observation will leave agents in the dark on the failure:

```none
> Encountered exception during tool call: unhandled errors in a TaskGroup (1 sub-exception)
```

This PR fixes that, by expanding `ExceptionGroup`s:

```none
> Encountered exception during tool call: unhandled errors in a TaskGroup (1 sub-exception), where sub-exceptions are: RuntimeError('BOOM, blew out an ACL.')
```