### PR TITLE
Allowing `litellm<1.72` in `llm` extra for working VCR

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,6 +80,7 @@ litqa = ["aviary.litqa"]
 llm = [
     "fhlmi",
     "litellm>=1.49.1",  # For removal of imghdr
+    "packaging",
 ]
 server = [
     "click",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,7 +51,7 @@ dev = [
     "fhaviary[image,llm,server,typing,xml]",
     "ipython>=8",  # Pin to keep recent
     "jupyter>=1.0.0",  # For running notebooks
-    "litellm>=1.65.5",  # Pin for sending tool schemae title in completions
+    "litellm>=1.65.5,<1.71",  # Lower pin for sending tool schemae title in completions, upper pin for VCR cassette breaks (https://github.com/BerriAI/litellm/issues/11724)
     "mypy>=1.8",  # Pin for mutable-override
     "numpy>=1",  # Pin to keep recent
     "pre-commit>=3.4",  # Pin to keep recent
@@ -79,7 +79,7 @@ lfrqa = ["aviary.lfrqa"]
 litqa = ["aviary.litqa"]
 llm = [
     "fhlmi",
-    "litellm>=1.72.0",  # Pin for fixed finish_reason when specifying a tool_choice
+    "litellm>=1.49.1",  # For removal of imghdr
 ]
 server = [
     "click",

--- a/src/aviary/tools/utils.py
+++ b/src/aviary/tools/utils.py
@@ -1,3 +1,4 @@
+import contextlib
 from collections.abc import Callable
 from functools import partial
 from typing import TYPE_CHECKING, Any, ClassVar, cast
@@ -38,14 +39,24 @@ class ToolSelector:
                 LiteLLM's Router.acompletion function for centralized rate limiting.
             accum_messages: Whether the selector should accumulate messages in a ledger.
         """
+        self._add_stop_reason_on_tool_choice_of_tool = True
         if acompletion is None:
             try:
                 from litellm import acompletion
+                from litellm._version import version as litellm_version  # noqa: PLC2701
+                from packaging import version
             except ImportError as e:
                 raise ImportError(
-                    f"{type(self).__name__} requires the 'llm' extra for 'litellm'."
-                    " Please: `pip install aviary[llm]`."
+                    f"{type(self).__name__} requires the 'llm' extra for"
+                    " 'litellm' and 'packaging'. Please: `pip install aviary[llm]`."
                 ) from e
+            with contextlib.suppress(version.InvalidVersion):
+                # litellm>=1.72.0 fixed the `finish_reason` being "stop"
+                # (instead of "tool_calls") when specifying a `tool_choice` as a `Tool`
+                self._add_stop_reason_on_tool_choice_of_tool = version.parse(
+                    litellm_version
+                ) < version.parse("1.72.0")
+
         self._model_name = model_name
         self._bound_acompletion = partial(cast("Callable", acompletion), model_name)
         self._ledger = ToolSelectorLedger() if accum_messages else None
@@ -69,6 +80,8 @@ class ToolSelector:
                 "type": "function",
                 "function": {"name": tool_choice.info.name},
             }
+            if self._add_stop_reason_on_tool_choice_of_tool:
+                expected_finish_reason.add("stop")
         elif tool_choice is not None:
             completion_kwargs["tool_choice"] = tool_choice
             if tool_choice == self.TOOL_CHOICE_REQUIRED:

--- a/tests/cassettes/TestParallelism.test_dummyenv_using_empty_params.yaml
+++ b/tests/cassettes/TestParallelism.test_dummyenv_using_empty_params.yaml
@@ -1,19 +1,12 @@
 interactions:
   - request:
       body:
-        '{"contents": [{"role": "user", "parts": [{"text": "Please get a random
-        integer."}]}], "tools": [{"function_declarations": [{"name": "print_story",
-        "description": "Print a story.", "parameters": {"type": "object", "properties":
-        {"story": {"description": "Story to print.", "title": "Story", "type": "string"}},
-        "required": ["story"]}}, {"name": "cast_float", "description": "Cast the input
-        argument x to a float.", "parameters": {"type": "object", "properties": {"x":
-        {"title": "X", "type": "string"}}, "required": ["x"]}}, {"name": "cast_int",
-        "description": "Cast the input argument x to an integer.", "parameters": {"type":
-        "object", "properties": {"x": {"title": "X", "type": "number"}}, "required":
-        ["x"]}}, {"name": "get_random_int", "description": "Get a random integer in
-        1 to 10.", "parameters": {"type": "object", "properties": {}, "required": []}}]}],
-        "toolConfig": {"functionCallingConfig": {"mode": "ANY"}}, "generationConfig":
-        {}}'
+        '{"contents":[{"role":"user","parts":[{"text":"Please get a random integer."}]}],"tools":[{"function_declarations":[{"name":"print_story","description":"Print
+        a story.","parameters":{"type":"object","properties":{"story":{"description":"Story
+        to print.","title":"Story","type":"string"}},"required":["story"]}},{"name":"cast_float","description":"Cast
+        the input argument x to a float.","parameters":{"type":"object","properties":{"x":{"title":"X","type":"string"}},"required":["x"]}},{"name":"cast_int","description":"Cast
+        the input argument x to an integer.","parameters":{"type":"object","properties":{"x":{"title":"X","type":"number"}},"required":["x"]}},{"name":"get_random_int","description":"Get
+        a random integer in 1 to 10.","parameters":{"type":"object","properties":{},"required":[]}}]}],"toolConfig":{"functionCallingConfig":{"mode":"ANY"}},"generationConfig":{}}'
       headers:
         accept:
           - "*/*"
@@ -22,24 +15,25 @@ interactions:
         connection:
           - keep-alive
         content-length:
-          - "943"
+          - "872"
         content-type:
           - application/json
         host:
           - generativelanguage.googleapis.com
         user-agent:
-          - litellm/1.65.5
+          - litellm/1.70.4
       method: POST
       uri: https://generativelanguage.googleapis.com/v1beta/models/gemini-1.5-flash:generateContent?key=%3CFILTERED%3E
     response:
       body:
         string: !!binary |
-          H4sIAAAAAAAC/61Ry26DMBC8+yuQzyEKBBLRa9pbq1YtqipVVbQNhlg1NrJNpQrx711ewaTXckD2
-          zO6Od6YhnkdPIDOegWWG3njviHhe0/87TknLpEVighCsQNu5dvga54wleS1Plit5ACEWzSMvoWSI
-          04LZo0Z9VR45yqyu60AXnVLTLgj3Np8/5m6qlejnlypjgo54OxXQnEtuzs8MjJJd2Uv6+HQRp/Bd
-          3Kui0uqz0/b36yAOk2AbRZswDHdBsmX+Zk8m8V6W1gYK9sAsoJFw2ZjikLKyqfpi8qDq3shdNAg5
-          vi/4eKStsiCWncnqz1Rzi5pcuHE4SeH6ILj96XZM795Sx2Ccv3jU5BFxrLx+4j+JxUstMiYzhPXK
-          tOFDKgUrMSc/WMd+LsCcKWnJL8XCVaeyAgAA
+          H4sIAAAAAAAC/61RXU/CMBR9369Y+swITMbAN4OakIgQXIyJMeTCLqOxa2fbacjCf7f7gg5f3cPS
+          3nPuPb3nFI7rkh3wmMagUZFb991UXLeo/iUmuEauDdCWTDEDqS/c+iuss6Hsc77TVPAZMNZpbnAO
+          KZo6SVBvpNEX6YYamd41D2RSKhWnDmDfLuePSzeRglXzUxEjI0391BLInnKqDmsEJXhJe4mWq7M4
+          ge/kSSSZFNtS2xv1/elwMroZB/7AH4d+OEVvEDqteCVLcgUJLlCDMRLOGxMzJM10JD6Rz0ReGRkO
+          ayHL9w4eNLAWGli3c9z7M1XdG03K7DispMz6wKg+ljtGD2+RZbCZ33lU65FjWXn9xH8SC7paTpNM
+          HdYrSkXrVBJMTU7esB94ewbqUA0kElUmuMJ5XHKW6vEZVvnXYpsn6XS+Ogq+ntz9EOfk/ALwP/QS
+          3QIAAA==
       headers:
         Alt-Svc:
           - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
@@ -48,11 +42,11 @@ interactions:
         Content-Type:
           - application/json; charset=UTF-8
         Date:
-          - Wed, 16 Apr 2025 17:50:49 GMT
+          - Sat, 14 Jun 2025 18:36:43 GMT
         Server:
           - scaffolding on HTTPServer2
         Server-Timing:
-          - gfet4t7; dur=654
+          - gfet4t7; dur=472
         Transfer-Encoding:
           - chunked
         Vary:

--- a/tests/cassettes/TestParallelism.test_tool_selector_from_model_name[gpt-4o-mini-2024-07-18].yaml
+++ b/tests/cassettes/TestParallelism.test_tool_selector_from_model_name[gpt-4o-mini-2024-07-18].yaml
@@ -1,20 +1,14 @@
 interactions:
   - request:
       body:
-        '{"messages": [{"role": "user", "content": "You are the president of the
-        United States of America. Please move both hands at the same time, and then
-        smile and wave."}], "model": "gpt-4o-mini-2024-07-18", "tool_choice": "required",
-        "tools": [{"type": "function", "function": {"name": "move_left_hand", "description":
-        "Move your left hand forward or backward.", "parameters": {"type": "object",
-        "properties": {"distance": {"description": "Integer distance to move (mm), where
-        forward is positive.", "title": "Distance", "type": "integer"}}, "required":
-        ["distance"]}}}, {"type": "function", "function": {"name": "move_right_hand",
-        "description": "Move your right hand forward or backward.", "parameters": {"type":
-        "object", "properties": {"distance": {"description": "Integer distance to move
-        (mm), where forward is positive.", "title": "Distance", "type": "integer"}},
-        "required": ["distance"]}}}, {"type": "function", "function": {"name": "smile_and_wave",
-        "description": "Smile and wave.", "parameters": {"type": "object", "properties":
-        {}, "required": []}}}]}'
+        '{"messages":[{"role":"user","content":"You are the president of the United
+        States of America. Please move both hands at the same time, and then smile and
+        wave."}],"model":"gpt-4o-mini-2024-07-18","tool_choice":"required","tools":[{"type":"function","function":{"name":"move_left_hand","description":"Move
+        your left hand forward or backward.","parameters":{"type":"object","properties":{"distance":{"description":"Integer
+        distance to move (mm), where forward is positive.","title":"Distance","type":"integer"}},"required":["distance"]}}},{"type":"function","function":{"name":"move_right_hand","description":"Move
+        your right hand forward or backward.","parameters":{"type":"object","properties":{"distance":{"description":"Integer
+        distance to move (mm), where forward is positive.","title":"Distance","type":"integer"}},"required":["distance"]}}},{"type":"function","function":{"name":"smile_and_wave","description":"Smile
+        and wave.","parameters":{"type":"object","properties":{},"required":[]}}}]}'
       headers:
         accept:
           - application/json
@@ -23,13 +17,13 @@ interactions:
         connection:
           - keep-alive
         content-length:
-          - "1060"
+          - "997"
         content-type:
           - application/json
         host:
           - api.openai.com
         user-agent:
-          - AsyncOpenAI/Python 1.50.2
+          - AsyncOpenAI/Python 1.86.0
         x-stainless-arch:
           - arm64
         x-stainless-async:
@@ -39,35 +33,36 @@ interactions:
         x-stainless-os:
           - MacOS
         x-stainless-package-version:
-          - 1.50.2
+          - 1.86.0
         x-stainless-raw-response:
           - "true"
+        x-stainless-read-timeout:
+          - "600.0"
         x-stainless-retry-count:
           - "0"
         x-stainless-runtime:
           - CPython
         x-stainless-runtime-version:
-          - 3.12.5
+          - 3.12.8
       method: POST
       uri: https://api.openai.com/v1/chat/completions
     response:
       body:
         string: !!binary |
-          H4sIAAAAAAAAAwAAAP//xFRdb5swFH3nV1j3OUyEko/mre2Wdd1aNV0fUq0TMuYCboyNbJOkjfLf
-          JyANJJ22vVTjAZl7OOfcY7jeOIQAj2FCgGXUsrwQ7tl0Vp5m8SUu6eXw7n5lx0pNmbJ4LqMAehVD
-          RU/I7CvrA1N5IdByJRuYaaQWK9X+yB/7QX/kDWogVzGKipYW1g2Um3PJXd/zA9cbuf3xjp0pztDA
-          hPxwCCFkU9+rPmWMa5gQr/daydEYmiJM9i8RAlqJqgLUGG4slRZ6LciUtCir1mUpRAewSomQUSFa
-          4+badNbtZlEhwvn96EKOfSk+Dsvb+Hy9Dlbp/NP1U8evkX4u6oaSUrL9JnXwfX1yZEYISJrX3Fwt
-          MRSY2DCjMj5SIASoTsscpa26h80jxHV0ho/VR/C8LRwQtp2nbe+fwp4s6Ge1sIO7F/5tpk9eUtQP
-          BadX7xZW8zT7b2n7J3r5ZX7Tj268q+lsML29uP768P1s+B5pTc4FhlTG4You8W9h/5Rtv/7Z+bE1
-          JqWhYvfHO0fbAEKlhVaROZoISLjkJgs1UlO3D8aqovGufGoHKA+mDwqt8sKGVi1QVoL9wG/0oD0h
-          WnQw3oFWWSrauu/tBvxQL4zRUl6P5/5EYJRlGLdUz+mEe2v6O4kmIJfpGxVnpwTm2VjMw4TLFHWh
-          eX18QFKEoyCiwSgKKANn6/wCAAD//wMA+sxjy0wFAAA=
+          H4sIAAAAAAAAAwAAAP//xFTJbtswEL3rKwie7UKSncW+JYDRIkWapY2DtgmICTWi2HBRScpxYvjf
+          C8mxJTtdcgmqgyDN45t5j+TMIiKEyoyOCeUFBK5L1T+WF+meE+JscDWdniaH1TGUV6k6m5zfTT7S
+          Xs2wdz+QhzXrHbe6VBikNSuYO4SAddbkYDgapftpnDSAthmqmibK0B/avpZG9tM4Hfbjg35y+Mwu
+          rOTo6Zh8jwghZNG8a50mwzkdk7i3jmj0HgTS8WYRIdRZVUcoeC99ABNorwW5NQFNLd1USnWAYK1i
+          HJRqC6+eRee73SxQiklRPGm4jkdPE/41NupJj07NEahOvVXqx7IRlFeGbzapg2/i451ihFADuuFq
+          O0OmMA+sAJPtZCCEghOVRhNq9XRxQ7PGOseb+hDieEm3CMvO37L3KrPzgZpezj5dzLEU397P8fzn
+          Q3Iy/3D0ZmadFMV/c3udHon7L5PLy2QgTox/iPfV/WecPr6FW6+lQgYmYw8ww3+Z/Zu3zfdt52I7
+          zCsP6uWNB2NsgFpdc+Vvo50dosqK0tk7v0OluTTSF8wh+MZZt3eitZBGAq222pOWzuoysGDvsSma
+          DJ97mbYjpEX312CwAVQbT+M1sJWPZRhANv27GRkceIFZS21HB1SZtB0g6nh/qeZ3uVf+pRGvSd8C
+          nGMZMGOlw0zybcftMof1hP3Tss0uN4KpRzeTHFmQ6OrzyDCHSq3mHvWPPqBmuTQCXelkM/xoXrLB
+          EPaGgKMBp9Ey+gUAAP//AwDlMamQCgYAAA==
       headers:
-        CF-Cache-Status:
-          - DYNAMIC
         CF-RAY:
-          - 8ce7f0a35fe87aec-SJC
+          - 94fbef48a81dcbab-LAX
         Connection:
           - keep-alive
         Content-Encoding:
@@ -75,14 +70,14 @@ interactions:
         Content-Type:
           - application/json
         Date:
-          - Sun, 06 Oct 2024 19:08:26 GMT
+          - Sat, 14 Jun 2025 18:36:42 GMT
         Server:
           - cloudflare
         Set-Cookie:
-          - __cf_bm=GjY6L5nQVhy3qyvZZh45To4HjtfEIOeYLpEnW99Zlk4-1728241706-1.0.1.1-MTMnx30mHdItVeNoUzyz9eoesXBXEOjAaXLa3pfM_ncPITfCy4WbtY0UVVBCfl_E9Y5bbJwdXDOOOKUpw26lCQ;
-            path=/; expires=Sun, 06-Oct-24 19:38:26 GMT; domain=.api.openai.com; HttpOnly;
+          - __cf_bm=a2am9V9P4.ul2caK.O8UFILEVQWGtVAgL8LBIKJNvfw-1749926202-1.0.1.1-p6TyCkUpINm6w4loZUyzMD3kBXqUUVtMv1.GhWkW_VREmf538w_kNqR6rGD5CTWJCHkTxt55I9VLX1TwS20ygvgXFcYrCnYW.QGy5C9oWl8;
+            path=/; expires=Sat, 14-Jun-25 19:06:42 GMT; domain=.api.openai.com; HttpOnly;
             Secure; SameSite=None
-          - _cfuvid=jOA7ZRL_JEhDd8CEGmU63H.GjAiFmWqDSqWbYnpD8o8-1728241706662-0.0.1.1-604800000;
+          - _cfuvid=t4eUyzu_jjJa7hDGlKOLM9puZuq7XGboHudn1Gp8K.8-1749926202593-0.0.1.1-604800000;
             path=/; domain=.api.openai.com; HttpOnly; Secure; SameSite=None
         Transfer-Encoding:
           - chunked
@@ -92,47 +87,45 @@ interactions:
           - X-Request-ID
         alt-svc:
           - h3=":443"; ma=86400
+        cf-cache-status:
+          - DYNAMIC
         openai-organization:
           - future-house-xr4tdh
         openai-processing-ms:
-          - "986"
+          - "795"
         openai-version:
           - "2020-10-01"
         strict-transport-security:
           - max-age=31536000; includeSubDomains; preload
+        x-envoy-upstream-service-time:
+          - "798"
         x-ratelimit-limit-requests:
           - "30000"
         x-ratelimit-limit-tokens:
           - "150000000"
         x-ratelimit-remaining-requests:
-          - "29998"
+          - "29999"
         x-ratelimit-remaining-tokens:
-          - "149999953"
+          - "149999968"
         x-ratelimit-reset-requests:
           - 2ms
         x-ratelimit-reset-tokens:
           - 0s
         x-request-id:
-          - req_1eac805d0dca14253c04482d805bb3ff
+          - req_d50afe83c456106203279cc8b04d326b
       status:
         code: 200
         message: OK
   - request:
       body:
-        '{"messages": [{"role": "user", "content": "You are the president of the
-        United States of America. Please move both hands at the same time, and then
-        smile and wave."}], "model": "gpt-4o-mini-2024-07-18", "tool_choice": "auto",
-        "tools": [{"type": "function", "function": {"name": "move_left_hand", "description":
-        "Move your left hand forward or backward.", "parameters": {"type": "object",
-        "properties": {"distance": {"description": "Integer distance to move (mm), where
-        forward is positive.", "title": "Distance", "type": "integer"}}, "required":
-        ["distance"]}}}, {"type": "function", "function": {"name": "move_right_hand",
-        "description": "Move your right hand forward or backward.", "parameters": {"type":
-        "object", "properties": {"distance": {"description": "Integer distance to move
-        (mm), where forward is positive.", "title": "Distance", "type": "integer"}},
-        "required": ["distance"]}}}, {"type": "function", "function": {"name": "smile_and_wave",
-        "description": "Smile and wave.", "parameters": {"type": "object", "properties":
-        {}, "required": []}}}]}'
+        '{"messages":[{"role":"user","content":"You are the president of the United
+        States of America. Please move both hands at the same time, and then smile and
+        wave."}],"model":"gpt-4o-mini-2024-07-18","tool_choice":"auto","tools":[{"type":"function","function":{"name":"move_left_hand","description":"Move
+        your left hand forward or backward.","parameters":{"type":"object","properties":{"distance":{"description":"Integer
+        distance to move (mm), where forward is positive.","title":"Distance","type":"integer"}},"required":["distance"]}}},{"type":"function","function":{"name":"move_right_hand","description":"Move
+        your right hand forward or backward.","parameters":{"type":"object","properties":{"distance":{"description":"Integer
+        distance to move (mm), where forward is positive.","title":"Distance","type":"integer"}},"required":["distance"]}}},{"type":"function","function":{"name":"smile_and_wave","description":"Smile
+        and wave.","parameters":{"type":"object","properties":{},"required":[]}}}]}'
       headers:
         accept:
           - application/json
@@ -141,13 +134,13 @@ interactions:
         connection:
           - keep-alive
         content-length:
-          - "1056"
+          - "993"
         content-type:
           - application/json
         host:
           - api.openai.com
         user-agent:
-          - AsyncOpenAI/Python 1.50.2
+          - AsyncOpenAI/Python 1.86.0
         x-stainless-arch:
           - arm64
         x-stainless-async:
@@ -157,35 +150,36 @@ interactions:
         x-stainless-os:
           - MacOS
         x-stainless-package-version:
-          - 1.50.2
+          - 1.86.0
         x-stainless-raw-response:
           - "true"
+        x-stainless-read-timeout:
+          - "600.0"
         x-stainless-retry-count:
           - "0"
         x-stainless-runtime:
           - CPython
         x-stainless-runtime-version:
-          - 3.12.5
+          - 3.12.8
       method: POST
       uri: https://api.openai.com/v1/chat/completions
     response:
       body:
         string: !!binary |
-          H4sIAAAAAAAAAwAAAP//xFRdb5swFH3nV1h+DhMQVFje0mlLV2Wb1qya1nZCxlzAqT+IbdKkUf77
-          BPmApNO2l2o8IHOP7zn3GN+7cRDCLMMjhGlJLBUVd8cfvtbjq/niexr/yG9u3gd27r8VVChz+yXA
-          gyZDpXOg9pD1hipRcbBMyR1MNRALDasfBXEQ+pF30QJCZcCbtKKybqhcwSRzAy8IXS9y/XifXSpG
-          weARuncQQmjTvps6ZQYrPELe4BARYAwpAI+OmxDCWvEmgokxzFgiLR50IFXSgmxKlzXnPcAqxRNK
-          OO+Ed8+mt+4Oi3CeCHs9TOVltILV0OpvvPhs1ovYxD29HfW6agvKa0mPh9TDj/HRmRhCWBLR5gq1
-          hIRDbpOSyOyMASFMdFELkLapHm8ecNZap/DQ/ARvi0/2b3tf28E/eX0Ox+8m64+yvF3Opnk0lDae
-          faLL2at51awo/5fZ+m66mg7lY75Wl1eT64mq9dh/Wixfw6wRjENCZJY8kSX8zeufvB3XP3vXWkNe
-          G8L39905OwbMVVFplZqzfsA5k8yUiQZi2vL77eEc1FodXJ90IK60EpVNrHoE2dD64b5dcTclOvTi
-          AFplCe/igXcATviSDCxhbYsepwIltISsS/WcnsWXor+j2NlksnjB4uyZsFkbCyLJmSxAV5q1IwTn
-          VRKFKQmjNCQUO1vnFwAAAP//AwCOLBC9UAUAAA==
+          H4sIAAAAAAAAAwAAAP//xFRdT9swFH3Pr7D83ExpGgrtWxHSphXYymAVG8hy7ZvExR+R7UBL1f8+
+          JaVNWvbBC1oeouQen3vPsX3vKkAIC46HCLOceqYKGZ6KSdw3/vzqzA5ObiYn8/6nb3rxfHZ2OXow
+          uFMxzGwOzG9ZH5hRhQQvjN7AzAL1UGXtHieDQdyPo7gGlOEgK1pW+DAxoRJahHEUJ2F0HHZPXti5
+          EQwcHqKfAUIIrep3pVNzWOAhijrbiALnaAZ4uFuEELZGVhFMnRPOU+1xpwGZ0R50JV2XUrYAb4wk
+          jErZFN48q9Z3s1lUSnI60X2ulupyARM+MvYmub0uz2PdqrdJvSxqQWmp2W6TWvguPjwohhDWVNVc
+          ZR6BSEg9yanmBxkQwtRmpQLtK/V4dYd5bZ3BXXUIUbTGe4R162/deZPZ3vJIwPTq4njqZ0+TL91b
+          cwH04/jzu5m1Isv/m9vrSfF9/OCnX597Qv8YD+bmalzepKP3cOuUkECo5uSJPsK/zP7N2+77vnWx
+          LaSlo/L1jadaG08rdfWVvw8OdghLkxXWzNwBFadCC5cTC9TVztq9E2yF1BJwudeeuLBGFZ548wB1
+          0W7y0su4GSEN2t+C3ngqm3gcbYG9fISDp6Lu393IYJTlwBtqMzpoyYVpAUHL+2s1v8u98S909pb0
+          DcAYFB44KSxwwfYdN8ssVBP2T8t2u1wLxg7so2BAvABbnQeHlJZyM/ewWzoPiqRCZ2ALK+rhh9OC
+          9BJ6lFAY9BgO1sEvAAAA//8DAG0ynAMKBgAA
       headers:
-        CF-Cache-Status:
-          - DYNAMIC
         CF-RAY:
-          - 8ce7f0aae8c07aec-SJC
+          - 94fbef4e8830cbab-LAX
         Connection:
           - keep-alive
         Content-Encoding:
@@ -193,7 +187,7 @@ interactions:
         Content-Type:
           - application/json
         Date:
-          - Sun, 06 Oct 2024 19:08:27 GMT
+          - Sat, 14 Jun 2025 18:36:43 GMT
         Server:
           - cloudflare
         Transfer-Encoding:
@@ -204,14 +198,18 @@ interactions:
           - X-Request-ID
         alt-svc:
           - h3=":443"; ma=86400
+        cf-cache-status:
+          - DYNAMIC
         openai-organization:
           - future-house-xr4tdh
         openai-processing-ms:
-          - "786"
+          - "752"
         openai-version:
           - "2020-10-01"
         strict-transport-security:
           - max-age=31536000; includeSubDomains; preload
+        x-envoy-upstream-service-time:
+          - "754"
         x-ratelimit-limit-requests:
           - "30000"
         x-ratelimit-limit-tokens:
@@ -219,13 +217,13 @@ interactions:
         x-ratelimit-remaining-requests:
           - "29999"
         x-ratelimit-remaining-tokens:
-          - "149999953"
+          - "149999968"
         x-ratelimit-reset-requests:
           - 2ms
         x-ratelimit-reset-tokens:
           - 0s
         x-request-id:
-          - req_78ba7fd6f2381afcca42b8ed1e88e153
+          - req_7c999009c14e502c9a1a35d94387e171
       status:
         code: 200
         message: OK

--- a/tests/cassettes/TestParallelism.test_tool_selector_with_external_acompletion[gpt-4o-mini-2024-07-18].yaml
+++ b/tests/cassettes/TestParallelism.test_tool_selector_with_external_acompletion[gpt-4o-mini-2024-07-18].yaml
@@ -1,20 +1,14 @@
 interactions:
   - request:
       body:
-        '{"messages": [{"role": "user", "content": "You are the president of the
-        United States of America. Please move both hands at the same time, and then
-        smile and wave."}], "model": "gpt-4o-mini-2024-07-18", "stream": false, "tool_choice":
-        "required", "tools": [{"type": "function", "function": {"name": "move_left_hand",
-        "description": "Move your left hand forward or backward.", "parameters": {"type":
-        "object", "properties": {"distance": {"description": "Integer distance to move
-        (mm), where forward is positive.", "title": "Distance", "type": "integer"}},
-        "required": ["distance"]}}}, {"type": "function", "function": {"name": "move_right_hand",
-        "description": "Move your right hand forward or backward.", "parameters": {"type":
-        "object", "properties": {"distance": {"description": "Integer distance to move
-        (mm), where forward is positive.", "title": "Distance", "type": "integer"}},
-        "required": ["distance"]}}}, {"type": "function", "function": {"name": "smile_and_wave",
-        "description": "Smile and wave.", "parameters": {"type": "object", "properties":
-        {}, "required": []}}}]}'
+        '{"messages":[{"role":"user","content":"You are the president of the United
+        States of America. Please move both hands at the same time, and then smile and
+        wave."}],"model":"gpt-4o-mini-2024-07-18","tool_choice":"required","tools":[{"type":"function","function":{"name":"move_left_hand","description":"Move
+        your left hand forward or backward.","parameters":{"type":"object","properties":{"distance":{"description":"Integer
+        distance to move (mm), where forward is positive.","title":"Distance","type":"integer"}},"required":["distance"]}}},{"type":"function","function":{"name":"move_right_hand","description":"Move
+        your right hand forward or backward.","parameters":{"type":"object","properties":{"distance":{"description":"Integer
+        distance to move (mm), where forward is positive.","title":"Distance","type":"integer"}},"required":["distance"]}}},{"type":"function","function":{"name":"smile_and_wave","description":"Smile
+        and wave.","parameters":{"type":"object","properties":{},"required":[]}}}]}'
       headers:
         accept:
           - application/json
@@ -23,13 +17,13 @@ interactions:
         connection:
           - keep-alive
         content-length:
-          - "1077"
+          - "997"
         content-type:
           - application/json
         host:
           - api.openai.com
         user-agent:
-          - AsyncOpenAI/Python 1.50.2
+          - AsyncOpenAI/Python 1.86.0
         x-stainless-arch:
           - arm64
         x-stainless-async:
@@ -39,35 +33,36 @@ interactions:
         x-stainless-os:
           - MacOS
         x-stainless-package-version:
-          - 1.50.2
+          - 1.86.0
         x-stainless-raw-response:
           - "true"
+        x-stainless-read-timeout:
+          - "6000.0"
         x-stainless-retry-count:
           - "0"
         x-stainless-runtime:
           - CPython
         x-stainless-runtime-version:
-          - 3.12.5
+          - 3.12.8
       method: POST
       uri: https://api.openai.com/v1/chat/completions
     response:
       body:
         string: !!binary |
-          H4sIAAAAAAAAA8RUXW/TMBR9z6+w7nOD0pAtW9+GWoqgDDaotsJQ5NpO4s1fjZ22o+p/R0m6Ju0Q
-          8DKRh8i5x/ecexzfu/EQAk5hgIDk2BFphH/x9qo8z8iH02x2Jd+Q01U45cHFp+HH+8VkBL0qQ8/v
-          GXFPWa+IlkYwx7VqYFIw7FjF2o/DszDqx8FJDUhNmajSMuP8SPuSK+6HQRj5Qez3z3bZueaEWRig
-          7x5CCG3qd1WnomwNAxT0niKSWYszBoP9JoSg0KKKALaWW4eVg14LEq0cU1XpqhSiAzitRUKwEK1w
-          82w66/awsBDJ+CuZL3GAR59vKF+Zm3fnExqvZ1lHr6F+NHVBaanI/pA6+D4+OBJDCBSWda7US5YI
-          lrokx4oeMSAEuMhKyZSrqofNHdDaOmF31U8ItnCwf9v52vb+yeso+nkr348W9lrq+Mswu7wcGpra
-          hxfzWvAs/19mb/GMpuOpXL2OJV0EajwdT9bX428vYdZKLliCFU1WeMn+5vVP3vbrH51rXbC0tFjs
-          7rt3dAwgdGYKPbdH/QApV9zmScGwrcsH67RptCudWgHKg94DU2hpXOL0A1MVYT8KGz5o50OLnpzt
-          QKcdFm08DHbtfciXUOYwr5tzPw8IJjmjbWrgdcw9F/0dRWOQq+wZi7djAvtoHZNJylXGClPwenhA
-          apI4muMonkeYgLf1fgEAAP//AwCjYIYGSgUAAA==
+          H4sIAAAAAAAAAwAAAP//xFRNb+IwEL3nV1g+wyqE8BGOqLtlu6gLagXdbivLOJPExbGztkNLEf+9
+          Sigk0P3opdocomSe38x7tmc2DkKYh3iAMEuoZWkmmkM+9Tri6ktvOho/jqbe9Wh9M0y637omir7i
+          RsFQiwdgds/6xFSaCbBcyR3MNFALRdZWzw8Cr+u5rRJIVQiioMWZbfqqmXLJm57r+U2312z1X9mJ
+          4gwMHqCfDkIIbcp3oVOG8IQHyG3sIykYQ2PAg8MihLBWoohgagw3lkqLGxXIlLQgC+kyF6IGWKUE
+          YVSIqvDu2dS+q82iQpDZ7eL6YtVfnc8+q2TY7bmXk5a/+jWs1dulXmeloCiX7LBJNfwQH5wUQwhL
+          mpbcVK2ACIgsSagMTzIghKmO8xSkLdTjzR0OS+sM7opDcN0tPiJsa3/bxrvMni2DZTt4nl9M7W2g
+          An/x8DSeuFPxYWY1j5P/5/Z8fjmeja/m8Y8FvTH9Tm+i1t+fzz7CrUm5AEJlSB7pCv5l9m/eDt/3
+          tYutIcoNFW9vPJVSWVqoK6/8vXOyQ1ioONNqYU6oOOKSm4RooKZ0Vu8dZy+klIDzo/bEmVZpZolV
+          SyiLtvzXXsbVCKnQ7h60ylJRxT13DxzlIyFYysv+PYwMRlkCYUWtRgfNQ65qgFPz/lbN73Lv/HMZ
+          vyd9BTAGmYWQZBpCzo4dV8s0FBP2T8sOu1wKxgb0ijMgloMuziOEiOZiN/ewWRsLKYm4jEFnmpfD
+          D0cZafu041MI2gw7W+cFAAD//wMA7b3InwoGAAA=
       headers:
-        CF-Cache-Status:
-          - DYNAMIC
         CF-RAY:
-          - 8ce7f0a34ad367d3-SJC
+          - 94fbef489ffef208-LAX
         Connection:
           - keep-alive
         Content-Encoding:
@@ -75,14 +70,14 @@ interactions:
         Content-Type:
           - application/json
         Date:
-          - Sun, 06 Oct 2024 19:08:26 GMT
+          - Sat, 14 Jun 2025 18:36:42 GMT
         Server:
           - cloudflare
         Set-Cookie:
-          - __cf_bm=Zj1HVlPzat2txEggSKv99KKn5dwTWg9NQSr18rVrk8I-1728241706-1.0.1.1-AwshqRQbghRTXm3UL2YId3qnltG.SLRLq5JGlPOgR7owudX2KQ0QNxWkjPBdnY3Gdq.j44APyStWSDZvLqCIoQ;
-            path=/; expires=Sun, 06-Oct-24 19:38:26 GMT; domain=.api.openai.com; HttpOnly;
+          - __cf_bm=OydJlGLWHJNIj72w6ZQ7PHtwdeK_GvL6vHJsGnTj0f8-1749926202-1.0.1.1-hN8UnVVJ46drlMMNNVRPf2zICFmJV3etVoNVNHHeT1kwAcow64PvowaBN6UMadJzthgOS3O5l3CsOp1VPDsKG48kmedzIQtWRpTvP2LwrJg;
+            path=/; expires=Sat, 14-Jun-25 19:06:42 GMT; domain=.api.openai.com; HttpOnly;
             Secure; SameSite=None
-          - _cfuvid=QJOgwn5rGdhwCIc.2DrTgvFTwX0u6diPhN5jfZm22_w-1728241706388-0.0.1.1-604800000;
+          - _cfuvid=4pp2.fAE3rmucrRa975kFXDp7f5lSCXGIo9P.iz2OCg-1749926202605-0.0.1.1-604800000;
             path=/; domain=.api.openai.com; HttpOnly; Secure; SameSite=None
         Transfer-Encoding:
           - chunked
@@ -92,14 +87,18 @@ interactions:
           - X-Request-ID
         alt-svc:
           - h3=":443"; ma=86400
+        cf-cache-status:
+          - DYNAMIC
         openai-organization:
           - future-house-xr4tdh
         openai-processing-ms:
-          - "706"
+          - "791"
         openai-version:
           - "2020-10-01"
         strict-transport-security:
           - max-age=31536000; includeSubDomains; preload
+        x-envoy-upstream-service-time:
+          - "819"
         x-ratelimit-limit-requests:
           - "30000"
         x-ratelimit-limit-tokens:
@@ -107,13 +106,13 @@ interactions:
         x-ratelimit-remaining-requests:
           - "29999"
         x-ratelimit-remaining-tokens:
-          - "149999953"
+          - "149999968"
         x-ratelimit-reset-requests:
           - 2ms
         x-ratelimit-reset-tokens:
           - 0s
         x-request-id:
-          - req_141a77ae216e3dcfeecdba5419734c30
+          - req_4426fea448c450dda4a9a23180f57974
       status:
         code: 200
         message: OK

--- a/uv.lock
+++ b/uv.lock
@@ -1178,8 +1178,8 @@ requires-dist = [
     { name = "httpx" },
     { name = "ipython", marker = "extra == 'dev'", specifier = ">=8" },
     { name = "jupyter", marker = "extra == 'dev'", specifier = ">=1.0.0" },
-    { name = "litellm", marker = "extra == 'dev'", specifier = ">=1.65.5" },
-    { name = "litellm", marker = "extra == 'llm'", specifier = ">=1.72.0" },
+    { name = "litellm", marker = "extra == 'dev'", specifier = ">=1.65.5,<1.71" },
+    { name = "litellm", marker = "extra == 'llm'", specifier = ">=1.49.1" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.8" },
     { name = "numpy", marker = "extra == 'dev'", specifier = ">=1" },
     { name = "numpy", marker = "extra == 'typing'" },
@@ -2212,7 +2212,7 @@ wheels = [
 
 [[package]]
 name = "litellm"
-version = "1.72.4"
+version = "1.70.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiohttp" },
@@ -2227,9 +2227,9 @@ dependencies = [
     { name = "tiktoken" },
     { name = "tokenizers" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/83/80/d73c821a2f65ee5b97b41e61d9b18324ebb9d616e1e21844f4253ac38957/litellm-1.72.4.tar.gz", hash = "sha256:8855de30f78bcb1f37af244519b37a37faaaf579401b1414400b5b5e5b616d57", size = 8132997, upload-time = "2025-06-11T05:46:38.041Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/60/d7/d0d76ba896a1e8978550dcc76157d1c50910ba9ade4ef3981a34f01f4fa6/litellm-1.70.4.tar.gz", hash = "sha256:ef6749a091faaaf88313afe4111cdd95736e1e60f21ba894e74f7c5bab2870bd", size = 7813817, upload-time = "2025-05-23T00:05:24.47Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/6f/0d/0f86db9724b9bd63d057b912aa6aa532a76e6e707f9bb75abbd3b0a0401a/litellm-1.72.4-py3-none-any.whl", hash = "sha256:f98ca994420ed649c466d423655a6e0f2aeecab4564ed372b3378a949e491dc2", size = 8036589, upload-time = "2025-06-11T05:46:34.727Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/8f/0b26ecb08b8282ae0fdfa2223b5df8263579c9e3c75ca96bb7fb7cbc632c/litellm-1.70.4-py3-none-any.whl", hash = "sha256:4d14d04bf5e2bd49336b4abc59193352c731ff371022e4fcf590208f41f644f7", size = 7903749, upload-time = "2025-05-23T00:05:21.017Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -1092,6 +1092,7 @@ dev = [
     { name = "litellm" },
     { name = "mypy" },
     { name = "numpy" },
+    { name = "packaging" },
     { name = "pandas-stubs" },
     { name = "pillow" },
     { name = "pre-commit" },
@@ -1130,6 +1131,7 @@ litqa = [
 llm = [
     { name = "fhlmi" },
     { name = "litellm" },
+    { name = "packaging" },
 ]
 server = [
     { name = "click" },
@@ -1183,6 +1185,7 @@ requires-dist = [
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.8" },
     { name = "numpy", marker = "extra == 'dev'", specifier = ">=1" },
     { name = "numpy", marker = "extra == 'typing'" },
+    { name = "packaging", marker = "extra == 'llm'" },
     { name = "pandas-stubs", marker = "extra == 'typing'" },
     { name = "pillow", marker = "extra == 'image'" },
     { name = "pre-commit", marker = "extra == 'dev'", specifier = ">=3.4" },


### PR DESCRIPTION
The backstory here is:

1. https://github.com/Future-House/aviary/pull/244 pinned `litellm>=1.72.0` for improved `finish_reason` logic
2. However, last night I discovered https://github.com/BerriAI/litellm/issues/11724

So this PR:

- Restores the versions from https://github.com/Future-House/aviary/pull/244
    - With the exception of the `paper-qa` edge case (as thanks to https://github.com/Future-House/paper-qa/pull/946, `paper-qa` now supports Python 3.13)
- Adds logic to check the `litellm` version at runtime, auto-selecting the appropriate validation behavior
- Refreshes all VCR cassettes using `ToolSelector`