### PR TITLE
Removed duplicated `TEvaluation` from LitQA

### DIFF
--- a/packages/litqa/src/aviary/envs/litqa/env.py
+++ b/packages/litqa/src/aviary/envs/litqa/env.py
@@ -25,6 +25,7 @@ else:
     from typing_extensions import TypeVar  # For TypeVar.default backport
 
 logger = logging.getLogger(__name__)
+
 TEvaluation = TypeVar("TEvaluation", default=MultipleChoiceEvaluation)
 
 DEFAULT_REWARD_MAPPING = {"correct": 1.0, "unsure": 0.1, "incorrect": -1.0}

--- a/packages/litqa/src/aviary/envs/litqa/task.py
+++ b/packages/litqa/src/aviary/envs/litqa/task.py
@@ -1,6 +1,5 @@
 import logging
 import re
-import sys
 from abc import ABC
 from collections.abc import Iterable, Mapping, Sequence
 from enum import StrEnum
@@ -24,7 +23,6 @@ from aviary.core import (
     TASK_DATASET_REGISTRY,
     Environment,
     Frame,
-    MultipleChoiceEvaluation,
     MultipleChoiceQuestion,
     TaskDataset,
     ToolResponseMessage,
@@ -40,14 +38,7 @@ if TYPE_CHECKING:
     from ldp.agent import Agent
     from ldp.data_structures import Transition
 
-if sys.version_info >= (3, 13):
-    from typing import TypeVar
-else:
-    from typing_extensions import TypeVar  # For TypeVar.default backport
-
 logger = logging.getLogger(__name__)
-
-TEvaluation = TypeVar("TEvaluation", default=MultipleChoiceEvaluation)
 
 
 DEFAULT_LABBENCH_HF_HUB_NAME = "futurehouse/lab-bench"


### PR DESCRIPTION
#190 seemingly duplicated `TEvaluation` in both `env.py` and `task.py`. It only needs to be in `env.py`