### PR TITLE
Downpinning `datasets` for its `trust_remote_code` deprecation

### DIFF
--- a/packages/hotpotqa/pyproject.toml
+++ b/packages/hotpotqa/pyproject.toml
@@ -19,7 +19,7 @@ classifiers = [
 ]
 dependencies = [
     "beautifulsoup4",
-    "datasets",
+    "datasets<4",  # Downpin for https://huggingface.co/datasets/hotpotqa/hotpot_qa/discussions/8
     "fhaviary",
     "httpx",
     "pydantic~=2.0",

--- a/uv.lock
+++ b/uv.lock
@@ -296,7 +296,7 @@ dependencies = [
 [package.metadata]
 requires-dist = [
     { name = "beautifulsoup4" },
-    { name = "datasets" },
+    { name = "datasets", specifier = "<4" },
     { name = "fhaviary", editable = "." },
     { name = "httpx" },
     { name = "pydantic", specifier = "~=2.0" },


### PR DESCRIPTION
See https://huggingface.co/datasets/hotpotqa/hotpot_qa/discussions/8 for rationale