### PR TITLE
Propagating #260 to publish CI

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -19,6 +19,8 @@ jobs:
         with:
           name: ${{ steps.build-fhaviary.outputs.artifact-name }}
           path: dist
+      - name: Clean up fhaviary build # Work around https://github.com/hynek/build-and-inspect-python-package/issues/174
+        run: rm -r ${{ steps.build-fhaviary.outputs.dist }}
       - id: build-aviary-gsm8k
         uses: hynek/build-and-inspect-python-package@v2
         with:
@@ -29,6 +31,8 @@ jobs:
         with:
           name: ${{ steps.build-aviary-gsm8k.outputs.artifact-name }}
           path: dist
+      - name: Clean up aviary.gsm8k build # Work around https://github.com/hynek/build-and-inspect-python-package/issues/174
+        run: rm -r ${{ steps.build-aviary-gsm8k.outputs.dist }}
       - id: build-aviary-hotpotqa
         uses: hynek/build-and-inspect-python-package@v2
         with:
@@ -39,6 +43,8 @@ jobs:
         with:
           name: ${{ steps.build-aviary-hotpotqa.outputs.artifact-name }}
           path: dist
+      - name: Clean up aviary.hotpotqa build # Work around https://github.com/hynek/build-and-inspect-python-package/issues/174
+        run: rm -r ${{ steps.build-aviary-hotpotqa.outputs.dist }}
       - id: build-aviary-litqa
         uses: hynek/build-and-inspect-python-package@v2
         with:
@@ -49,6 +55,8 @@ jobs:
         with:
           name: ${{ steps.build-aviary-litqa.outputs.artifact-name }}
           path: dist
+      - name: Clean up aviary.litqa build # Work around https://github.com/hynek/build-and-inspect-python-package/issues/174
+        run: rm -r ${{ steps.build-aviary-litqa.outputs.dist }}
       - id: build-aviary-lfrqa
         uses: hynek/build-and-inspect-python-package@v2
         with:
@@ -59,6 +67,8 @@ jobs:
         with:
           name: ${{ steps.build-aviary-lfrqa.outputs.artifact-name }}
           path: dist
+      - name: Clean up aviary.lfrqa build # Work around https://github.com/hynek/build-and-inspect-python-package/issues/174
+        run: rm -r ${{ steps.build-aviary-lfrqa.outputs.dist }}
       - uses: pypa/gh-action-pypi-publish@release/v1
         with:
           password: ${{ secrets.PYPI_API_TOKEN }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -72,6 +72,26 @@ jobs:
       - name: Clean up aviary.hotpotqa build # Work around https://github.com/hynek/build-and-inspect-python-package/issues/174
         if: matrix.python-version == '3.11'
         run: rm -r ${{ steps.build-hotpotqa.outputs.dist }}
+      - name: Check aviary.litqa build
+        id: build-litqa
+        if: matrix.python-version == '3.11'
+        uses: hynek/build-and-inspect-python-package@v2
+        with:
+          path: packages/litqa
+          upload-name-suffix: -litqa
+      - name: Clean up aviary.litqa build # Work around https://github.com/hynek/build-and-inspect-python-package/issues/174
+        if: matrix.python-version == '3.11'
+        run: rm -r ${{ steps.build-litqa.outputs.dist }}
+      - name: Check aviary.lfrqa build
+        id: build-lfrqa
+        if: matrix.python-version == '3.11'
+        uses: hynek/build-and-inspect-python-package@v2
+        with:
+          path: packages/lfrqa
+          upload-name-suffix: -lfrqa
+      - name: Clean up aviary.lfrqa build # Work around https://github.com/hynek/build-and-inspect-python-package/issues/174
+        if: matrix.python-version == '3.11'
+        run: rm -r ${{ steps.build-lfrqa.outputs.dist }}
       - run: uv sync --python-preference=only-managed
       - run: uv run refurb .
       - run: uv run pylint src packages

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -44,14 +44,16 @@ jobs:
           enable-cache: true
       - run: uv python pin ${{ matrix.python-version }}
       - name: Check fhaviary build
+        id: build-fhaviary
         if: matrix.python-version == '3.11'
         uses: hynek/build-and-inspect-python-package@v2
         with:
           upload-name-suffix: -fhaviary
       - name: Clean up fhaviary build # Work around https://github.com/hynek/build-and-inspect-python-package/issues/174
         if: matrix.python-version == '3.11'
-        run: rm -r /tmp/baipp/dist
+        run: rm -r ${{ steps.build-fhaviary.outputs.dist }}
       - name: Check aviary.gsm8k build
+        id: build-gsm8k
         if: matrix.python-version == '3.11'
         uses: hynek/build-and-inspect-python-package@v2
         with:
@@ -59,8 +61,9 @@ jobs:
           upload-name-suffix: -gsm8k
       - name: Clean up aviary.gsm8k build # Work around https://github.com/hynek/build-and-inspect-python-package/issues/174
         if: matrix.python-version == '3.11'
-        run: rm -r /tmp/baipp/dist
+        run: rm -r ${{ steps.build-gsm8k.outputs.dist }}
       - name: Check aviary.hotpotqa build
+        id: build-hotpotqa
         if: matrix.python-version == '3.11'
         uses: hynek/build-and-inspect-python-package@v2
         with:
@@ -68,7 +71,7 @@ jobs:
           upload-name-suffix: -hotpotqa
       - name: Clean up aviary.hotpotqa build # Work around https://github.com/hynek/build-and-inspect-python-package/issues/174
         if: matrix.python-version == '3.11'
-        run: rm -r /tmp/baipp/dist
+        run: rm -r ${{ steps.build-hotpotqa.outputs.dist }}
       - run: uv sync --python-preference=only-managed
       - run: uv run refurb .
       - run: uv run pylint src packages


### PR DESCRIPTION
This PR also:
- Uses `steps.` references to avoid repeating the string literal `/tmp/baipp/dist` a bunch
- Fixed <https://github.com/Future-House/aviary/pull/190> forgetting to add `aviary.litqa` and `aviary.lfrqa` to `lint`'s build step