### PR TITLE
Lower pinning `datasets` to ensure modern `pyarrow` compatibility

### DIFF
--- a/packages/gsm8k/pyproject.toml
+++ b/packages/gsm8k/pyproject.toml
@@ -18,7 +18,7 @@ classifiers = [
     "Topic :: Scientific/Engineering :: Artificial Intelligence",
 ]
 dependencies = [
-    "datasets",
+    "datasets>=2.15",  # Lower pin for https://github.com/huggingface/datasets/pull/6404
     "fhaviary",
     "pydantic~=2.0",
 ]

--- a/packages/hotpotqa/pyproject.toml
+++ b/packages/hotpotqa/pyproject.toml
@@ -19,7 +19,7 @@ classifiers = [
 ]
 dependencies = [
     "beautifulsoup4",
-    "datasets<4",  # Downpin for https://huggingface.co/datasets/hotpotqa/hotpot_qa/discussions/8
+    "datasets>=2.15,<4",  # Lower pin for https://github.com/huggingface/datasets/pull/6404, upper pin for https://huggingface.co/datasets/hotpotqa/hotpot_qa/discussions/8
     "fhaviary",
     "httpx",
     "pydantic~=2.0",

--- a/packages/litqa/pyproject.toml
+++ b/packages/litqa/pyproject.toml
@@ -33,7 +33,9 @@ readme = "README.md"
 requires-python = ">=3.11"
 
 [project.optional-dependencies]
-datasets = ["datasets"]
+datasets = [
+    "datasets>=2.15",  # Lower pin for https://github.com/huggingface/datasets/pull/6404
+]
 
 [tool.ruff]
 extend = "../../pyproject.toml"

--- a/uv.lock
+++ b/uv.lock
@@ -266,7 +266,7 @@ typing = [
 
 [package.metadata]
 requires-dist = [
-    { name = "datasets" },
+    { name = "datasets", specifier = ">=2.15" },
     { name = "fhaviary", editable = "." },
     { name = "pandas-stubs", marker = "extra == 'typing'" },
     { name = "pydantic", specifier = "~=2.0" },
@@ -288,7 +288,7 @@ dependencies = [
 [package.metadata]
 requires-dist = [
     { name = "beautifulsoup4" },
-    { name = "datasets", specifier = "<4" },
+    { name = "datasets", specifier = ">=2.15,<4" },
     { name = "fhaviary", editable = "." },
     { name = "httpx" },
     { name = "pydantic", specifier = "~=2.0" },
@@ -335,7 +335,7 @@ datasets = [
 
 [package.metadata]
 requires-dist = [
-    { name = "datasets", marker = "extra == 'datasets'" },
+    { name = "datasets", marker = "extra == 'datasets'", specifier = ">=2.15" },
     { name = "fhaviary", editable = "." },
     { name = "fhlmi" },
     { name = "ldp", specifier = ">=0.25.2" },


### PR DESCRIPTION
I had a `uv lock --upgrade` lead to hitting `AttributeError: module 'pyarrow' has no attribute 'PyExtensionType'` from somewhere in Hugging Face `datasets`. Upon investigation, it turns out the lock resolution had downgraded to a super old `datasets` version.

https://github.com/apache/arrow/issues/47155 reveals we should just lower-pin `datasets` to a somewhat modern (Nov 2023) version, which is what this PR does.