### PR TITLE
Deprecate open answer from MultipleChoiceQuestion

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -222,6 +222,7 @@ disable = [
     "broad-exception-raised",  # Rely on ruff TRY002 for this
     "cyclic-import",  # Let Python blow up
     "dangerous-default-value",  # Rely on ruff W0102 for this
+    "duplicate-code",  # Too aggressive
     "empty-docstring",  # Let pep257 take care of docstrings
     "expression-not-assigned",  # Rely on mypy func-returns-value for this
     "fixme",  # codetags are useful

--- a/src/aviary/utils.py
+++ b/src/aviary/utils.py
@@ -300,6 +300,13 @@ class MultipleChoiceQuestion(BaseModel):
             " if worried about the model memorizing question IDs."
         ),
     )
+    prompt_without_options: bool = Field(
+        default=False,
+        description=(
+            "Opt-in flag to exclude options from the question_prompt, effectively"
+            " making the prompt be open answer."
+        ),
+    )
     options: Sequence[str] = Field(description="All multiple choice options.")
     ideal_answer: str = Field(
         description=(

--- a/src/aviary/utils.py
+++ b/src/aviary/utils.py
@@ -274,9 +274,8 @@ _CAPITAL_A_INDEX = ord("A")
 class MultipleChoiceQuestion(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
-    OPEN_ANSWER_PROMPT_TEMPLATE: ClassVar[str] = "{question_id}: {question}"
     MC_QUESTION_PROMPT_TEMPLATE: ClassVar[str] = "\n\n".join((
-        OPEN_ANSWER_PROMPT_TEMPLATE,
+        "{question_id}: {question}",
         "Options:\n{options}",
     ))
     DEFAULT_UNSURE_OPTION: ClassVar[str] = (
@@ -390,8 +389,6 @@ class MultipleChoiceQuestion(BaseModel):
                 else self.question_id
             ),
         }
-        if self.prompt_without_options:
-            return self.OPEN_ANSWER_PROMPT_TEMPLATE.format(**template_vars)
         return self.MC_QUESTION_PROMPT_TEMPLATE.format(
             options="\n".join([
                 f"{_CAPITAL_A_INDEX + i:c}) {o}" for i, o in enumerate(self.options)

--- a/src/aviary/utils.py
+++ b/src/aviary/utils.py
@@ -418,9 +418,6 @@ class MultipleChoiceQuestion(BaseModel):
     async def grade(
         self, proposed_answer: str, llm_eval_config: dict[str, Any] | None = None
     ) -> "tuple[MultipleChoiceEvaluation, str | None]":
-        if not self.options:
-            raise RuntimeError("Cannot grade a question with no options.")
-
         extracted_answer = await extract_answer(
             proposed_answer=proposed_answer,
             options=self.options,

--- a/src/aviary/utils.py
+++ b/src/aviary/utils.py
@@ -300,13 +300,6 @@ class MultipleChoiceQuestion(BaseModel):
             " if worried about the model memorizing question IDs."
         ),
     )
-    prompt_without_options: bool = Field(
-        default=False,
-        description=(
-            "Opt-in flag to exclude options from the question_prompt, effectively"
-            " making the prompt be open answer."
-        ),
-    )
     options: Sequence[str] = Field(description="All multiple choice options.")
     ideal_answer: str = Field(
         description=(

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -346,7 +346,7 @@ class TestLitQAEvaluation:
             "Different seeding strategies should lead to different prompts"
         )
 
-    async def test_no_options(self) -> None:
+    def test_no_options(self) -> None:
         question, ideal, _ = self.MEANING_OF_LIFE_QUESTION_IDEAL_DISTRACTORS
         mcq = MultipleChoiceQuestion(
             question=question,

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -346,7 +346,6 @@ class TestLitQAEvaluation:
             "Different seeding strategies should lead to different prompts"
         )
 
-    @pytest.mark.asyncio
     async def test_no_options(self) -> None:
         question, ideal, _ = self.MEANING_OF_LIFE_QUESTION_IDEAL_DISTRACTORS
         mcq = MultipleChoiceQuestion(
@@ -363,11 +362,6 @@ class TestLitQAEvaluation:
         assert mcq == mcq_copy, (
             "Serialization then deserialization should lead to same prompts"
         )
-
-        with pytest.raises(
-            RuntimeError, match="Cannot grade a question with no options"
-        ):
-            await mcq.grade("The answer is 42")
 
     @pytest.mark.parametrize(
         (

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -168,12 +168,11 @@ class TestLitQAEvaluation:
         question: str,
         ideal_answer: str,
         distractors: Iterable[str],
-        is_open_answer: bool = False,
     ) -> None:
         question_prompt = mc_question.question_prompt
         assert question_prompt.count(question) == 1
         for substr in ("Insufficient information", ideal_answer, *distractors):
-            assert question_prompt.count(substr) == (1 if not is_open_answer else 0)
+            assert question_prompt.count(substr) == 1
 
     # Use for general purpose testing
     ZIP_CODE_QUESTION_IDEAL_DISTRACTORS = (
@@ -339,41 +338,6 @@ class TestLitQAEvaluation:
         )
         assert mc_question_2a != mc_question_1a, (
             "Different seeding strategies should lead to different prompts"
-        )
-
-    def test_consistent_open_answer(self) -> None:
-        question, ideal, distractors = self.MEANING_OF_LIFE_QUESTION_IDEAL_DISTRACTORS
-        mc_question_1a = MultipleChoiceQuestion(
-            question=question,
-            ideal_answer=ideal,
-            options=distractors,
-            shuffle_seed=0,
-            prompt_without_options=True,
-        )
-        self._assert_prompt_is_valid(
-            mc_question_1a, question, ideal, distractors, is_open_answer=True
-        )
-
-        mc_question_1b = MultipleChoiceQuestion(
-            question=question,
-            ideal_answer=ideal,
-            options=distractors,
-            shuffle_seed=0,
-            prompt_without_options=True,
-        )
-        self._assert_prompt_is_valid(
-            mc_question_1b, question, ideal, distractors, is_open_answer=True
-        )
-        assert mc_question_1a == mc_question_1b, (
-            "Same seeding should lead to same prompts"
-        )
-
-        mc_question_1a_copy = MultipleChoiceQuestion(**mc_question_1a.model_dump())
-        self._assert_prompt_is_valid(
-            mc_question_1a_copy, question, ideal, distractors, is_open_answer=True
-        )
-        assert mc_question_1a == mc_question_1a_copy == mc_question_1b, (
-            "Serialization then deserialization should lead to same prompts"
         )
 
     @pytest.mark.parametrize(


### PR DESCRIPTION
As the title says. It was confusing for a class named MCQ to support non-MCQs. And as I've run into a few times the past couple days, we have downstream code that breaks silently if you use `MultipleChoiceQuestion` in open-answer mode (i.e. `.grade` will mark everything as wrong). 

As far as I can tell, nobody is using this code path, so I am removing it to avoid confusion. We should bring it back as a separate class eventually, with proper downstream support. 