### PR TITLE
Pulled in PaperQA's `gen_answer`'s empty docs fix

### DIFF
--- a/packages/litqa/pyproject.toml
+++ b/packages/litqa/pyproject.toml
@@ -38,7 +38,7 @@ datasets = [
 ]
 dev = [
     "aviary.litqa[datasets]",
-    "paper-qa>=5.29.0",  # Pin for gen_answer's EmptyDocsError
+    "paper-qa>=5.29.1",  # Pin for gen_answer's EmptyDocsError, with fix
 ]
 
 [tool.ruff]

--- a/packages/litqa/tests/test_litqa_env.py
+++ b/packages/litqa/tests/test_litqa_env.py
@@ -3,7 +3,7 @@ import time
 from collections.abc import Iterable
 from copy import deepcopy
 from typing import ClassVar, cast
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 from uuid import UUID, uuid4
 
 import pytest
@@ -14,7 +14,7 @@ from paperqa import Docs, Settings
 from paperqa.agents import get_directory_index
 from paperqa.agents.env import PaperQAEnvironment
 from paperqa.agents.tools import Complete, GatherEvidence, GenerateAnswer
-from paperqa.types import Doc, PQASession
+from paperqa.prompts import CANNOT_ANSWER_PHRASE
 from pytest_subtests import SubTests
 
 from aviary.core import (
@@ -439,41 +439,16 @@ class TestGradablePaperQAEnvironment:
         agent_test_settings: Settings,
         stub_gradable_env: GradablePaperQAEnvironment,
     ) -> None:
-        unsure_answer = "Based on the sources provided, it appears no one has done x."
-
-        async def custom_aget_evidence(*_, **kwargs) -> PQASession:  # noqa: RUF029
-            return kwargs["query"]
-
-        async def emulate_answered_but_unsure(  # noqa: RUF029
-            *_, query: PQASession, **__
-        ) -> PQASession:
-            query.answer = unsure_answer
-            return query
-
         reset_obs, tools = await stub_gradable_env.reset()
 
-        # 1. Emulate being unsure after gen_answer
+        # 1. Immediately call gen_answer without paper search/evidence gathering
         answer_action = ToolRequestMessage(
             tool_calls=[ToolCall.from_name("gen_answer")]
         )
-
-        with (
-            patch.object(
-                stub_gradable_env.state.docs,
-                "docs",
-                {"stub_key": MagicMock(spec_set=Doc)},
-            ),
-            patch.multiple(
-                type(stub_gradable_env.state.docs),
-                clear_docs=MagicMock(),
-                aget_evidence=custom_aget_evidence,
-                aquery=emulate_answered_but_unsure,
-            ),
-        ):
-            answer_obs, _, done, truncated = await stub_gradable_env.step(answer_action)
+        answer_obs, _, done, truncated = await stub_gradable_env.step(answer_action)
         assert len(answer_obs) == 1
         assert answer_obs[0].content
-        assert unsure_answer in answer_obs[0].content
+        assert CANNOT_ANSWER_PHRASE in answer_obs[0].content
         assert not done
         assert not truncated
 

--- a/uv.lock
+++ b/uv.lock
@@ -378,7 +378,7 @@ requires-dist = [
     { name = "fhlmi" },
     { name = "ldp", specifier = ">=0.25.2" },
     { name = "paper-qa", specifier = ">=5.14.0" },
-    { name = "paper-qa", marker = "extra == 'dev'", specifier = ">=5.29.0" },
+    { name = "paper-qa", marker = "extra == 'dev'", specifier = ">=5.29.1" },
     { name = "pydantic", specifier = "~=2.0" },
     { name = "tenacity" },
     { name = "typing-extensions", marker = "python_full_version < '3.13'" },
@@ -2293,7 +2293,7 @@ wheels = [
 
 [[package]]
 name = "paper-qa"
-version = "5.29.0"
+version = "5.29.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiohttp" },
@@ -2313,9 +2313,9 @@ dependencies = [
     { name = "tenacity" },
     { name = "tiktoken" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/e1/b9/758f8dd0f10b2afd4ce4381415c69d3943f48b2554328e03f100818cb969/paper_qa-5.29.0.tar.gz", hash = "sha256:f466588baca224f84447df36818749b88845f148be763ccf0ebec9aa90aae2a5", size = 4378219, upload-time = "2025-08-25T23:06:00.458Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a6/6a/be74dd213749007fdc2ce1df27b37db7eeb6fad9f1e234adb3d6c4c84f87/paper_qa-5.29.1.tar.gz", hash = "sha256:c7c6b5403867d3c8b147d25053d4083cc9979152476fd8a535b7a3257e7b68fa", size = 4378256, upload-time = "2025-08-26T21:41:41.136Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/98/68/388e21322eacb580f09bcc51f5204d278f64092709d219f0ed6203d3f125/paper_qa-5.29.0-py3-none-any.whl", hash = "sha256:af70e8f05790c5ee1b4e14825ce18af86f2180ce9454c672a514c5b67af633ea", size = 520171, upload-time = "2025-08-25T23:05:56.32Z" },
+    { url = "https://files.pythonhosted.org/packages/85/0f/91f37ee9aff695ad2e1c478d5d1c19ccfd5703b359a984ab11141a77ac88/paper_qa-5.29.1-py3-none-any.whl", hash = "sha256:bdd5ff496e8cfdf661f749e71b2491a112cbe8ac7f707670c7e396ee69b9c003", size = 520237, upload-time = "2025-08-26T21:41:37.193Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
In https://github.com/Future-House/aviary/pull/276 I adjusted `test_unsure_answer` for https://github.com/Future-House/paper-qa/pull/1073.

However, https://github.com/Future-House/paper-qa/pull/1077 soon fixed an issue with it (see the PR description), so this PR re-adjusts `test_unsure_answer`.

You can see how PaperQA is improved, due to the simplification of the code.