### PR TITLE
Fixing `shuffle`'s `NameError: name 'np' is not defined` and type errors

### DIFF
--- a/src/aviary/utils.py
+++ b/src/aviary/utils.py
@@ -93,7 +93,7 @@ class EvalAnswerMode(StrEnum):
         return {}
 
 
-def partial_format(value: str, **formats: dict[str, Any]) -> str:
+def partial_format(value: str, **formats) -> str:
     """Partially format a string given a variable amount of formats."""
     for template_key, template_value in formats.items():
         with contextlib.suppress(KeyError):


### PR DESCRIPTION
Running `pytest -n auto tests` today from the repo root, I was getting this error on any test using `shuffle`

```none
>   ???
E   NameError: name 'np' is not defined
```

I fixed it by adding a `SeedTypes` type alias.

This also seemingly allowed `typeguard` to now detect an incorrect type hint in `partial_format`, which this PR fixes too.