### PR TITLE
Moving from `pre-commit/action` to `j178/prek-action`

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,17 +17,13 @@ jobs:
       - uses: actions/checkout@v5
         with:
           fetch-depth: 0 # For setuptools-scm, replace with fetch-tags after https://github.com/actions/checkout/issues/1471
-      - uses: actions/setup-python@v5
-        with:
-          python-version: ${{ matrix.python-version }}
       - uses: astral-sh/setup-uv@v6
         with:
           enable-cache: true
-      - run: echo "UV_PROJECT_ENVIRONMENT=$(python -c "import sysconfig; print(sysconfig.get_config_var('prefix'))")" >> $GITHUB_ENV
-      - run: uv python pin ${{ matrix.python-version }} # uv requires .python-version to match OS Python: https://github.com/astral-sh/uv/issues/11389
-      - run: uv sync --python-preference only-system
-      - run: git checkout .python-version # For clean git diff given `pre-commit run --show-diff-on-failure`
-      - uses: pre-commit/action@v3.0.1
+          python-version: ${{ matrix.python-version }}
+          activate-environment: true # Activate for simple `uv sync` below
+      - run: uv sync
+      - uses: j178/prek-action@v1
       - uses: pre-commit-ci/lite-action@v1.1.0
         if: always()
   lint:


### PR DESCRIPTION
This PR moves CI from `pre-commit/action` to `j178/prek-action`.

We can now do this after https://github.com/j178/prek/issues/14 was fixed in today's https://github.com/j178/prek/tree/v0.2.3.