### PR TITLE
Fixing `uv` cache not existing

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -42,6 +42,7 @@ jobs:
       - uses: astral-sh/setup-uv@v6
         with:
           enable-cache: true
+          cache-local-path: /tmp/baipp-uv_cache_dir # Work around https://github.com/hynek/build-and-inspect-python-package/issues/181
           python-version: ${{ matrix.python-version }}
       - name: Unset UV_PYTHON for BAIPP # SEE: https://github.com/hynek/build-and-inspect-python-package/issues/180
         run: echo "UV_PYTHON=" >> "$GITHUB_ENV"


### PR DESCRIPTION
Our `lint` GitHub Action workflow uses both `astral-sh/setup-uv` and `hynek/build-and-inspect-python-package`. It turns both actions' usage of `UV_CACHE_DIR` led to conflicts. During the Post Run of `setup-uv`, as seen in [this CI run](https://github.com/Future-House/aviary/actions/runs/18104191690/job/51514500472), we'd flakily hit an error on cache save:

```none
Post job cleanup.
Pruning cache...
Saving cache path: /home/runner/work/_temp/setup-uv-cache
Error: Cache path /home/runner/work/_temp/setup-uv-cache does not exist on disk. This likely indicates that there are no dependencies to cache. Consider disabling the cache input if it is not needed.
```

This PR fixes the problem by syncing the two GitHub Actions to use the same underlying cache location.

See also: https://github.com/astral-sh/setup-uv/issues/592 --> https://github.com/hynek/build-and-inspect-python-package/issues/181