### PR TITLE
Allowing latest `datasets`

### DIFF
--- a/packages/hotpotqa/pyproject.toml
+++ b/packages/hotpotqa/pyproject.toml
@@ -19,7 +19,7 @@ classifiers = [
 ]
 dependencies = [
     "beautifulsoup4",
-    "datasets>=2.15,<4",  # Lower pin for https://github.com/huggingface/datasets/pull/6404, upper pin for https://huggingface.co/datasets/hotpotqa/hotpot_qa/discussions/8
+    "datasets>=2.15",  # Lower pin for https://github.com/huggingface/datasets/pull/6404
     "fhaviary",
     "httpx",
     "httpx-aiohttp",

--- a/uv.lock
+++ b/uv.lock
@@ -806,7 +806,7 @@ wheels = [
 
 [[package]]
 name = "datasets"
-version = "3.6.0"
+version = "4.1.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "dill" },
@@ -823,9 +823,9 @@ dependencies = [
     { name = "tqdm" },
     { name = "xxhash" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/1a/89/d3d6fef58a488f8569c82fd293ab7cbd4250244d67f425dcae64c63800ea/datasets-3.6.0.tar.gz", hash = "sha256:1b2bf43b19776e2787e181cfd329cb0ca1a358ea014780c3581e0f276375e041", size = 569336, upload-time = "2025-05-07T15:15:02.659Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/91/a4/73f8e6ef52c535e1d20d5b2ca83bfe6de399d8b8b8a61ccc8d63d60735aa/datasets-4.1.1.tar.gz", hash = "sha256:7d8d5ba8b12861d2c44bfff9c83484ebfafff1ff553371e5901a8d3aab5450e2", size = 579324, upload-time = "2025-09-18T13:14:27.108Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/20/34/a08b0ee99715eaba118cbe19a71f7b5e2425c2718ef96007c325944a1152/datasets-3.6.0-py3-none-any.whl", hash = "sha256:25000c4a2c0873a710df127d08a202a06eab7bf42441a6bc278b499c2f72cd1b", size = 491546, upload-time = "2025-05-07T15:14:59.742Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/c8/09012ac195a0aab58755800d2efdc0e7d5905053509f12cb5d136c911cda/datasets-4.1.1-py3-none-any.whl", hash = "sha256:62e4f6899a36be9ec74a7e759a6951253cc85b3fcfa0a759b0efa8353b149dac", size = 503623, upload-time = "2025-09-18T13:14:25.111Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = ">=3.11"
 resolution-markers = [
     "python_full_version >= '3.14' and platform_python_implementation == 'PyPy'",
@@ -303,7 +303,7 @@ dependencies = [
 [package.metadata]
 requires-dist = [
     { name = "beautifulsoup4" },
-    { name = "datasets", specifier = ">=2.15,<4" },
+    { name = "datasets", specifier = ">=2.15" },
     { name = "fhaviary", editable = "." },
     { name = "httpx" },
     { name = "httpx-aiohttp" },


### PR DESCRIPTION
https://github.com/Future-House/aviary/pull/261 had downpinned `datasets` for `aviary.hotpotqa`. Then later in https://huggingface.co/datasets/hotpotqa/hotpot_qa/discussions/8 this was resolved within Hugging Face. So this PR once again allows `datasets` version 4.