### PR TITLE
Fix multimodal serialization

### DIFF
--- a/src/aviary/message.py
+++ b/src/aviary/message.py
@@ -119,7 +119,7 @@ class Message(BaseModel):
         data = handler(self)
         deserialize_content = (info.context or {}).get("deserialize_content", True)
         if deserialize_content and "content" in data:
-            data["content"] = self.serialized_content
+            data["content"] = self.deserialized_content
 
         # Handle cache_breakpoint - add cache_control to content
         # Skip when deserialize_content=False as it would convert string to list,
@@ -148,6 +148,9 @@ class Message(BaseModel):
 
         if (info.context or {}).get("include_info"):
             data["info"] = self.info
+            # content_is_json_str is exclude=True so it's dropped by handler().
+            # Persist it here so serialization round-trips (dump → validate_python)
+            # can recover multimodal status without relying on content being a list.
             if self.content_is_json_str:
                 data["content_is_json_str"] = True
         return data
@@ -172,7 +175,7 @@ class Message(BaseModel):
         )
 
     @property
-    def serialized_content(self) -> str | list | None:
+    def deserialized_content(self) -> str | list | None:
         """Content in API-ready form: list for multimodal, string otherwise."""
         if self.is_multimodal:
             return json.loads(self.content)  # type: ignore[arg-type]

--- a/src/aviary/message.py
+++ b/src/aviary/message.py
@@ -118,8 +118,8 @@ class Message(BaseModel):
         """
         data = handler(self)
         deserialize_content = (info.context or {}).get("deserialize_content", True)
-        if self.is_multimodal and "content" in data and deserialize_content:
-            data["content"] = json.loads(data["content"])
+        if deserialize_content and "content" in data:
+            data["content"] = self.serialized_content
 
         # Handle cache_breakpoint - add cache_control to content
         # Skip when deserialize_content=False as it would convert string to list,
@@ -148,6 +148,8 @@ class Message(BaseModel):
 
         if (info.context or {}).get("include_info"):
             data["info"] = self.info
+            if self.content_is_json_str:
+                data["content_is_json_str"] = True
         return data
 
     def __str__(self) -> str:
@@ -168,6 +170,13 @@ class Message(BaseModel):
             isinstance(item, dict) and item.get("type") in {"text", "image_url"}
             for item in parsed
         )
+
+    @property
+    def serialized_content(self) -> str | list | None:
+        """Content in API-ready form: list for multimodal, string otherwise."""
+        if self.is_multimodal:
+            return json.loads(self.content)  # type: ignore[arg-type]
+        return self.content
 
     def append_text(self, text: str, delim: str = "\n", inplace: bool = True) -> Self:
         """Append text to the content.

--- a/tests/test_messages.py
+++ b/tests/test_messages.py
@@ -190,15 +190,15 @@ class TestMessage:
                 },
             ],
         )
-        assert original.content_is_json_str is True
-        assert original.is_multimodal is True
+        assert original.content_is_json_str
+        assert original.is_multimodal
 
         dumped = original.model_dump(mode="json", context={"include_info": True})
         assert dumped["content_is_json_str"] is True
 
         recovered = Message.model_validate(dumped)
-        assert recovered.content_is_json_str is True
-        assert recovered.is_multimodal is True
+        assert recovered.content_is_json_str
+        assert recovered.is_multimodal
 
     def test_multimodal_roundtrip_via_string_content(self) -> None:
         """Multimodal content survives when stored dict has content as a list."""
@@ -215,8 +215,8 @@ class TestMessage:
         assert isinstance(dumped["content"], list)
 
         recovered = Message.model_validate(dumped)
-        assert recovered.content_is_json_str is True
-        assert recovered.is_multimodal is True
+        assert recovered.content_is_json_str
+        assert recovered.is_multimodal
 
     @pytest.mark.parametrize(
         ("images", "message_text", "expected_error", "expected_content_length"),

--- a/tests/test_messages.py
+++ b/tests/test_messages.py
@@ -184,15 +184,16 @@ class TestMessage:
         original = Message(
             content=[
                 {"type": "text", "text": "Look at this"},
-                {"type": "image_url", "image_url": {"url": "data:image/png;base64,abc"}},
+                {
+                    "type": "image_url",
+                    "image_url": {"url": "data:image/png;base64,abc"},
+                },
             ],
         )
         assert original.content_is_json_str is True
         assert original.is_multimodal is True
 
-        dumped = original.model_dump(
-            mode="json", context={"include_info": True}
-        )
+        dumped = original.model_dump(mode="json", context={"include_info": True})
         assert dumped["content_is_json_str"] is True
 
         recovered = Message.model_validate(dumped)
@@ -204,7 +205,10 @@ class TestMessage:
         original = Message(
             content=[
                 {"type": "text", "text": "Look at this"},
-                {"type": "image_url", "image_url": {"url": "data:image/png;base64,abc"}},
+                {
+                    "type": "image_url",
+                    "image_url": {"url": "data:image/png;base64,abc"},
+                },
             ],
         )
         dumped = original.model_dump(mode="json")

--- a/tests/test_messages.py
+++ b/tests/test_messages.py
@@ -119,6 +119,25 @@ class TestMessage:
                 {"context": {"include_info": True}},
                 {"role": "user", "content": "stub", "info": {"foo": "bar"}},
             ),
+            (
+                Message(
+                    content=[
+                        {"type": "text", "text": "stub"},
+                        {"type": "image_url", "image_url": {"url": "stub_url"}},
+                    ],
+                    info={"k": "v"},
+                ),
+                {"context": {"include_info": True}},
+                {
+                    "role": "user",
+                    "content": [
+                        {"type": "text", "text": "stub"},
+                        {"type": "image_url", "image_url": {"url": "stub_url"}},
+                    ],
+                    "info": {"k": "v"},
+                    "content_is_json_str": True,
+                },
+            ),
         ],
     )
     def test_dump(self, message: Message, dump_kwargs: dict, expected: dict) -> None:
@@ -159,6 +178,41 @@ class TestMessage:
             json.loads(message.model_dump_json(exclude_none=True, **dump_kwargs))
             == expected
         )
+
+    def test_multimodal_roundtrip_via_include_info(self) -> None:
+        """Multimodal content_is_json_str survives dump→validate when include_info is set."""
+        original = Message(
+            content=[
+                {"type": "text", "text": "Look at this"},
+                {"type": "image_url", "image_url": {"url": "data:image/png;base64,abc"}},
+            ],
+        )
+        assert original.content_is_json_str is True
+        assert original.is_multimodal is True
+
+        dumped = original.model_dump(
+            mode="json", context={"include_info": True}
+        )
+        assert dumped["content_is_json_str"] is True
+
+        recovered = Message.model_validate(dumped)
+        assert recovered.content_is_json_str is True
+        assert recovered.is_multimodal is True
+
+    def test_multimodal_roundtrip_via_string_content(self) -> None:
+        """Multimodal content survives when stored dict has content as a list."""
+        original = Message(
+            content=[
+                {"type": "text", "text": "Look at this"},
+                {"type": "image_url", "image_url": {"url": "data:image/png;base64,abc"}},
+            ],
+        )
+        dumped = original.model_dump(mode="json")
+        assert isinstance(dumped["content"], list)
+
+        recovered = Message.model_validate(dumped)
+        assert recovered.content_is_json_str is True
+        assert recovered.is_multimodal is True
 
     @pytest.mark.parametrize(
         ("images", "message_text", "expected_error", "expected_content_length"),

--- a/tests/test_messages.py
+++ b/tests/test_messages.py
@@ -211,10 +211,7 @@ class TestMessage:
                 },
             ],
         )
-        dumped = original.model_dump(mode="json")
-        assert isinstance(dumped["content"], list)
-
-        recovered = Message.model_validate(dumped)
+        recovered = Message.model_validate(original.model_dump(mode="json"))
         assert recovered.content_is_json_str
         assert recovered.is_multimodal
 


### PR DESCRIPTION
1. We were losing `content_is_json_str`
2. Downstream code would sometimes incorrectly check `Message.content`, which can sometimes be a serialized list. As a helper, we provide `Message.serialized_content`. Should we cache this? Up for discussion. 