### PR TITLE
Updated dependencies using `deptry`, modernized tooling

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -93,6 +93,12 @@ jobs:
         run: rm -r ${{ steps.build-lfrqa.outputs.dist }}
       - run: uv sync
       - run: uv run refurb .
+      - name: Run deptry
+        run: |
+          uv run deptry .
+          for pkg in packages/*/; do
+            uv run --directory "$pkg" deptry .
+          done
       - run: uv run pylint src packages
       - if: matrix.python-version == '3.11' # Only need to run this on one version
         uses: suzuki-shunsuke/github-action-renovate-config-validator@v2.1.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,13 +20,13 @@ repos:
       - id: mixed-line-ending
       - id: trailing-whitespace
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.15.7
+    rev: v0.15.10
     hooks:
       - id: ruff-check
         args: [--fix, --exit-non-zero-on-fix]
       - id: ruff-format
   - repo: https://github.com/rbubley/mirrors-prettier
-    rev: v3.8.1
+    rev: v3.8.3
     hooks:
       - id: prettier
   - repo: https://github.com/Yelp/detect-secrets
@@ -49,7 +49,7 @@ repos:
         additional_dependencies: [".[toml]"]
         exclude_types: [jupyter]
   - repo: https://github.com/pappasam/toml-sort
-    rev: v0.24.3
+    rev: v0.24.4
     hooks:
       - id: toml-sort-fix
         exclude: ^uv\.lock$
@@ -71,11 +71,11 @@ repos:
     hooks:
       - id: pymarkdown
   - repo: https://github.com/henryiii/validate-pyproject-schema-store
-    rev: 2026.01.02
+    rev: 2026.04.16
     hooks:
       - id: validate-pyproject
   - repo: https://github.com/astral-sh/uv-pre-commit
-    rev: 0.10.12
+    rev: 0.11.7
     hooks:
       - id: uv-lock
   - repo: local # Use local to ensure we don't pull aviary from PyPI

--- a/packages/gsm8k/pyproject.toml
+++ b/packages/gsm8k/pyproject.toml
@@ -30,6 +30,11 @@ readme = "README.md"
 requires-python = ">=3.11"
 
 [project.optional-dependencies]
+dev = [
+    "aviary.gsm8k[typing]",
+    "pytest",
+    "pytest-asyncio",
+]
 typing = [
     "pandas-stubs",
 ]

--- a/packages/gsm8k/pyproject.toml
+++ b/packages/gsm8k/pyproject.toml
@@ -39,6 +39,16 @@ typing = [
     "pandas-stubs",
 ]
 
+[tool.deptry]
+# Work around https://github.com/osprey-oss/deptry/issues/302: un-exclude tests
+exclude = ["\\.direnv", "\\.git", "\\.venv", "setup\\.py", "venv"]
+known_first_party = ["aviary"]
+optional_dependencies_dev_groups = ["dev", "typing"]
+
+[tool.deptry.per_rule_ignores]
+# Work around https://github.com/osprey-oss/deptry/issues/1533
+DEP004 = ["pytest"]
+
 [tool.ruff]
 extend = "../../pyproject.toml"
 

--- a/packages/hotpotqa/pyproject.toml
+++ b/packages/hotpotqa/pyproject.toml
@@ -39,6 +39,16 @@ dev = [
     "pytest-asyncio",
 ]
 
+[tool.deptry]
+# Work around https://github.com/osprey-oss/deptry/issues/302: un-exclude tests
+exclude = ["\\.direnv", "\\.git", "\\.venv", "setup\\.py", "venv"]
+known_first_party = ["aviary"]
+optional_dependencies_dev_groups = ["dev"]
+
+[tool.deptry.per_rule_ignores]
+# Work around https://github.com/osprey-oss/deptry/issues/1533
+DEP004 = ["pytest"]
+
 [tool.ruff]
 extend = "../../pyproject.toml"
 

--- a/packages/hotpotqa/pyproject.toml
+++ b/packages/hotpotqa/pyproject.toml
@@ -33,6 +33,12 @@ name = "aviary.hotpotqa"
 readme = "README.md"
 requires-python = ">=3.11"
 
+[project.optional-dependencies]
+dev = [
+    "pytest",
+    "pytest-asyncio",
+]
+
 [tool.ruff]
 extend = "../../pyproject.toml"
 

--- a/packages/labbench/pyproject.toml
+++ b/packages/labbench/pyproject.toml
@@ -45,6 +45,16 @@ dev = [
 ]
 typing = ["pillow"]
 
+[tool.deptry]
+# Work around https://github.com/osprey-oss/deptry/issues/302: un-exclude tests
+exclude = ["\\.direnv", "\\.git", "\\.venv", "setup\\.py", "venv"]
+known_first_party = ["aviary"]
+optional_dependencies_dev_groups = ["dev", "typing"]
+
+[tool.deptry.per_rule_ignores]
+# Work around https://github.com/osprey-oss/deptry/issues/1533
+DEP004 = ["pandas", "pytest"]
+
 [tool.ruff]
 extend = "../../pyproject.toml"
 

--- a/packages/labbench/pyproject.toml
+++ b/packages/labbench/pyproject.toml
@@ -23,8 +23,6 @@ dependencies = [
     "fhlmi",
     "ldp>=0.25.2",  # Pin for lmi migration
     "paper-qa[pymupdf]>=2025",  # Pin for multimodal
-    "pydantic~=2.0",
-    "tenacity",
     "typing-extensions; python_version <= '3.12'",  # For TypeVar default
 ]
 description = "LAB-Bench environments implemented with aviary"
@@ -41,6 +39,8 @@ dev = [
     "aviary.labbench[datasets,typing]",
     "pandas",
     "paper-qa>=5.29.1",  # Pin for gen_answer's EmptyDocsError, with fix
+    "pytest-asyncio",
+    "pytest>=9",  # For pytest-subtests upstreaming
     "tantivy>=0.25.0; python_version >= '3.14'",  # For Python 3.14 support
 ]
 typing = ["pillow"]

--- a/packages/labbench/tests/test_tasks.py
+++ b/packages/labbench/tests/test_tasks.py
@@ -23,7 +23,6 @@ from paperqa import Docs, Settings
 from paperqa.agents import get_directory_index
 from paperqa.agents.env import PaperQAEnvironment
 from paperqa.agents.tools import GenerateAnswer
-from pytest_subtests import SubTests
 
 from aviary.envs.labbench import (
     DEFAULT_REWARD_MAPPING,
@@ -179,7 +178,7 @@ class TestPaperQATaskDataset:
 
     @pytest.mark.asyncio
     async def test_evaluation(
-        self, subtests: SubTests, agent_task_settings: Settings
+        self, subtests: pytest.Subtests, agent_task_settings: Settings
     ) -> None:
         await get_directory_index(settings=agent_task_settings)  # Build
         docs = Docs()

--- a/packages/lfrqa/pyproject.toml
+++ b/packages/lfrqa/pyproject.toml
@@ -33,7 +33,11 @@ requires-python = ">=3.11"
 
 [project.optional-dependencies]
 csv = ["pandas"]
-dev = ["aviary.lfrqa[csv]"]
+dev = [
+    "aviary.lfrqa[csv]",
+    "pytest",
+    "pytest-asyncio",
+]
 
 [tool.ruff]
 extend = "../../pyproject.toml"

--- a/packages/lfrqa/pyproject.toml
+++ b/packages/lfrqa/pyproject.toml
@@ -39,6 +39,17 @@ dev = [
     "pytest-asyncio",
 ]
 
+[tool.deptry]
+# Work around https://github.com/osprey-oss/deptry/issues/302: un-exclude tests
+exclude = ["\\.direnv", "\\.git", "\\.venv", "setup\\.py", "venv"]
+known_first_party = ["aviary"]
+optional_dependencies_dev_groups = ["dev"]
+
+[tool.deptry.per_rule_ignores]
+# Work around https://github.com/osprey-oss/deptry/issues/1533
+DEP003 = ["ldp"]
+DEP004 = ["pytest"]
+
 [tool.ruff]
 extend = "../../pyproject.toml"
 

--- a/packages/notebook/pyproject.toml
+++ b/packages/notebook/pyproject.toml
@@ -43,6 +43,19 @@ dev = [
     "pytest-asyncio",
 ]
 
+[tool.deptry]
+# Work around https://github.com/osprey-oss/deptry/issues/302: un-exclude tests
+exclude = ["\\.direnv", "\\.git", "\\.venv", "setup\\.py", "venv"]
+known_first_party = ["aviary"]
+optional_dependencies_dev_groups = ["dev"]
+
+[tool.deptry.per_rule_ignores]
+DEP002 = [
+    "ipykernel",  # Launched indirectly by jupyter-client's python kernelspec
+]
+# Work around https://github.com/osprey-oss/deptry/issues/1533
+DEP004 = ["pytest"]
+
 [tool.ruff]
 extend = "../../pyproject.toml"
 

--- a/packages/notebook/pyproject.toml
+++ b/packages/notebook/pyproject.toml
@@ -28,6 +28,7 @@ dependencies = [
     "nbformat",
     "numpy",
     "pydantic~=2.0",
+    "typing-extensions; python_version < '3.13'",  # For TypeVar default
 ]
 description = "Jupyter notebook environment implemented with aviary"
 dynamic = ["version"]
@@ -38,6 +39,8 @@ requires-python = ">=3.11"
 [project.optional-dependencies]
 dev = [
     "matplotlib",  # Needed to run tests with plots
+    "pytest",
+    "pytest-asyncio",
 ]
 
 [tool.ruff]

--- a/packages/notebook/src/aviary/envs/notebook/utils.py
+++ b/packages/notebook/src/aviary/envs/notebook/utils.py
@@ -200,11 +200,11 @@ async def nbformat_run_notebook(  # noqa: D417
         cells: Notebook cell dictionaries to execute sequentially
         client: KernelClient instance to use for code execution
 
-    Raises:
-        ValueError: If there is an error executing a cell
-
     Returns:
         List of error messages from cells that raised an error
+
+    Raises:
+        ValueError: If there is an error executing a cell
     """  # noqa: DOC502
     error_messages = []
     logger.debug(f"Running notebook with cell_idx: {cell_idx}")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ dependencies = [
     "docstring_parser>=0.16",  # Pin for description addition
     "httpx",
     "httpx-aiohttp",
+    "pydantic-core",
     "pydantic~=2.0",
 ]
 description = "Gymnasium framework for training language model agents on constructive tasks"
@@ -40,8 +41,8 @@ cloud = [
     "boto3",
 ]
 dev = [
-    "aviary.gsm8k[typing]",
-    "aviary.hotpotqa",
+    "aviary.gsm8k[dev]",
+    "aviary.hotpotqa[dev]",
     "aviary.labbench[dev]",
     "aviary.lfrqa[dev]",
     "aviary.notebook[dev]",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,6 +46,7 @@ dev = [
     "aviary.labbench[dev]",
     "aviary.lfrqa[dev]",
     "aviary.notebook[dev]",
+    "deptry",
     "fhaviary[image,llm,server,typing,xml]",
     "ipython>=8",  # Pin to keep recent
     "jupyter>=1.0.0",  # For running notebooks
@@ -117,6 +118,17 @@ skip = [
     "tests/fixtures/test_images/*",
     "tests/stub_data/*",
 ]
+
+[tool.deptry]
+# Work around https://github.com/osprey-oss/deptry/issues/302: un-exclude tests
+exclude = ["\\.direnv", "\\.git", "\\.venv", "setup\\.py", "venv"]
+extend_exclude = ["packages", "tutorials"]
+known_first_party = ["aviary"]
+optional_dependencies_dev_groups = ["dev", "typing"]
+
+[tool.deptry.per_rule_ignores]
+# Work around https://github.com/osprey-oss/deptry/issues/1533
+DEP004 = ["numpy", "pytest", "pytest_asyncio", "tenacity", "typeguard", "vcr"]
 
 [tool.markdown_toc_creator]
 horizontal-rule-style = "prettier"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -278,6 +278,7 @@ disable = [
     "too-many-instance-attributes",  # Don't care to enforce this
     "too-many-lines",  # Don't care to enforce this
     "too-many-locals",  # Rely on ruff PLR0914 for this
+    "too-many-nested-blocks",  # Rely on ruff PLR1702 for this
     "too-many-positional-arguments",  # Rely on ruff PLR0917 for this
     "too-many-public-methods",  # Rely on ruff PLR0904 for this
     "too-many-return-statements",  # Rely on ruff PLR0911 for this
@@ -365,14 +366,16 @@ preview = true
 [tool.ruff.lint]
 explicit-preview-rules = true
 extend-select = [
-    "ASYNC212",
-    "ASYNC240",
-    "ASYNC250",
+    "AIR003",
+    "AIR303",
+    "AIR304",
+    "AIR321",
+    "B043",
     "B901",
     "B903",
     "B909",
-    "B912",
     "CPY001",
+    "D420",
     "DOC102",
     "DOC201",
     "DOC202",
@@ -423,7 +426,6 @@ extend-select = [
     "E502",
     "FURB101",
     "FURB103",
-    "FURB110",
     "FURB113",
     "FURB118",
     "FURB131",
@@ -435,13 +437,11 @@ extend-select = [
     "FURB154",
     "FURB156",
     "FURB164",
-    "FURB171",
     "FURB180",
     "FURB189",
     "FURB192",
     "ISC004",
     "LOG004",
-    "PLC0207",
     "PLC1901",
     "PLC2701",
     "PLC2801",
@@ -456,10 +456,10 @@ extend-select = [
     "PLR0917",
     "PLR1702",
     "PLR1708",
+    "PLR1712",
     "PLR6104",
     "PLR6201",
     "PLR6301",
-    "PLW0108",
     "PLW0244",
     "PLW1514",
     "PLW3201",
@@ -468,24 +468,27 @@ extend-select = [
     "RUF029",
     "RUF031",
     "RUF036",
-    "RUF037",
     "RUF038",
     "RUF039",
     "RUF045",
     "RUF047",
+    "RUF050",
     "RUF052",
     "RUF054",
     "RUF055",
     "RUF056",
-    "RUF060",
-    "RUF061",
     "RUF063",
-    "RUF064",
     "RUF065",
     "RUF066",
-    "RUF102",
+    "RUF067",
+    "RUF068",
+    "RUF069",
+    "RUF070",
+    "RUF071",
+    "RUF072",
+    "RUF073",
     "TC008",
-    "UP042",
+    "TID254",
     "W391",
 ]
 external = [
@@ -541,6 +544,7 @@ ignore = [
     "PLW2901",  # Allow modifying loop variables
     "PTH",  # Overly pedantic
     "RUF027",  # Prompt templates may not be f-strings
+    "RUF067",  # Don't care to disallow code in __init__.py
     "S101",  # Don't care to prevent asserts
     "S105",  # Duplicates Yelp/detect-secrets in pre-commit
     "S311",  # Ok to use python random
@@ -576,9 +580,11 @@ mypy-init-return = true
     "F841",  # Tests can have unused locals
     "N802",  # Tests function names can match class names
     "PLC2701",  # Test can import private names if needed
+    "PLR0904",  # Test classes can have many cases
     "PLR2004",  # Tests can have magic values
     "PLR6301",  # Test classes can ignore self
     "RUF059",  # Tests can have unused unpacks, for readability
+    "RUF069",  # Tests can have float equality
     "S101",  # Tests can have assertions
 ]
 "docs/**.ipynb" = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,11 +58,10 @@ dev = [
     "pytest-asyncio",
     "pytest-recording",
     "pytest-rerunfailures",
-    "pytest-subtests",
     "pytest-sugar",
     "pytest-timer[colorama]",
     "pytest-xdist",
-    "pytest>=8",  # Pin to keep recent
+    "pytest>=9",  # For pytest-subtests upstreaming
     "refurb>=2",  # Pin to keep recent
     "tenacity",
     "typeguard",
@@ -320,10 +319,10 @@ plugins.no-duplicate-heading.siblings_only = true  # GitHub appends -X for dupli
 plugins.no-emphasis-as-heading.enabled = false
 plugins.no-inline-html.enabled = false
 
-[tool.pytest.ini_options]
+[tool.pytest]
 # Add the specified OPTS to the set of command line arguments as if they had been
 # specified by the user.
-addopts = "--typeguard-packages=aviary --doctest-modules"
+addopts = ["--doctest-modules", "--typeguard-packages=aviary"]
 # Sets a list of filters and actions that should be taken for matched warnings.
 # By default all warnings emitted during the test session will be displayed in
 # a summary at the end of the test session.

--- a/src/aviary/core.py
+++ b/src/aviary/core.py
@@ -88,7 +88,6 @@ __all__ = [
     "argref_by_name",
     "encode_image_to_base64",
     "eval_answer",
-    "eval_answer",
     "extract_answer",
     "fenv",
     "is_coroutine_callable",

--- a/src/aviary/utils.py
+++ b/src/aviary/utils.py
@@ -486,12 +486,12 @@ class MultipleChoiceEvaluation(StrEnum):
         """
         Calculate QA-specific accuracy and precision metrics upon evaluations.
 
-        Raises:
-            ZeroDivisionError: if an empty input.
-
         Returns:
             Two-tuple of accuracy = (num correct) / (num questions) and
                 precision = (num correct) / ((num questions) - (num unsure)).
+
+        Raises:
+            ZeroDivisionError: if an empty input.
         """  # noqa: DOC502
         evaluations = [e if isinstance(e, cls) else cls(e) for e in evaluations]
         num_correct = sum(e == cls.CORRECT for e in evaluations)

--- a/tests/test_envs.py
+++ b/tests/test_envs.py
@@ -16,7 +16,6 @@ import pytest_asyncio
 from fastapi import APIRouter, FastAPI
 from httpx import ASGITransport, AsyncClient
 from pydantic import BaseModel, ValidationError
-from pytest_subtests import SubTests
 
 from aviary.core import (
     DummyEnv,
@@ -407,7 +406,7 @@ class TestRendering:
         mutable_state[0].append("bar")
         assert deep_copy.model_dump()["state"] == [["foo"]]
 
-    def test_rendering(self, dummy_env: DummyEnv, subtests: SubTests) -> None:
+    def test_rendering(self, dummy_env: DummyEnv, subtests: pytest.Subtests) -> None:
         # Reset to add state
         asyncio.run(dummy_env.reset())
         frame_after_reset = dummy_env.export_frame()
@@ -592,7 +591,7 @@ class TestParallelism:
     @pytest.mark.parametrize("model_name", [CILLMModelNames.OPENAI.value])
     @pytest.mark.asyncio
     async def test_tool_selector_from_model_name(
-        self, subtests: SubTests, model_name: str
+        self, subtests: pytest.Subtests, model_name: str
     ) -> None:
         env = ParallelizedDummyEnv()
         obs, tools = await env.reset()

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -13,7 +13,6 @@ import pytest
 from fastapi.testclient import TestClient
 from PIL import Image, ImageDraw, ImageFont
 from pydantic import BaseModel, Field
-from pytest_subtests import SubTests
 from tenacity import retry, retry_if_exception_type, stop_after_attempt
 from typeguard import suppress_type_checks
 
@@ -513,7 +512,7 @@ PARAMETERS:
         tool = Tool.from_function(fn, **kwargs)
         assert tool.info.describe_str().strip() == expected
 
-    def test_describe(self, subtests: SubTests) -> None:
+    def test_describe(self, subtests: pytest.Subtests) -> None:
         """Test that describe_xyz functions for FunctionInfo are reasonable."""
         tool = Tool.from_function(many_edge_cases)
 
@@ -609,7 +608,7 @@ PARAMETERS:
 
     @pytest.mark.asyncio
     async def test_tool_serialization(  # noqa: PLR0915
-        self, dummy_env: DummyEnv, subtests: SubTests
+        self, dummy_env: DummyEnv, subtests: pytest.Subtests
     ) -> None:
         def get_todo_list(n: int):
             """Get todo list for today.

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -8,7 +8,6 @@ import numpy as np
 import pytest
 from PIL import Image
 from pydantic import BaseModel
-from pytest_subtests import SubTests
 
 from aviary.core import (
     MultipleChoiceEvaluation,
@@ -496,7 +495,7 @@ def test_partial_format(value: str, formats: dict[str, Any], expected: str) -> N
     ],
 )
 def test_encode_image_to_base64(
-    subtests: SubTests,
+    subtests: pytest.Subtests,
     raw_image_file: str,
     b64_image_file: str,
     format: str,  # noqa: A002

--- a/uv.lock
+++ b/uv.lock
@@ -319,18 +319,26 @@ dependencies = [
 ]
 
 [package.optional-dependencies]
+dev = [
+    { name = "pandas-stubs" },
+    { name = "pytest" },
+    { name = "pytest-asyncio" },
+]
 typing = [
     { name = "pandas-stubs" },
 ]
 
 [package.metadata]
 requires-dist = [
+    { name = "aviary-gsm8k", extras = ["typing"], marker = "extra == 'dev'", editable = "packages/gsm8k" },
     { name = "datasets", specifier = ">=2.15" },
     { name = "fhaviary", editable = "." },
     { name = "pandas-stubs", marker = "extra == 'typing'" },
     { name = "pydantic", specifier = "~=2.0" },
+    { name = "pytest", marker = "extra == 'dev'" },
+    { name = "pytest-asyncio", marker = "extra == 'dev'" },
 ]
-provides-extras = ["typing"]
+provides-extras = ["dev", "typing"]
 
 [[package]]
 name = "aviary-hotpotqa"
@@ -345,6 +353,12 @@ dependencies = [
     { name = "tenacity" },
 ]
 
+[package.optional-dependencies]
+dev = [
+    { name = "pytest" },
+    { name = "pytest-asyncio" },
+]
+
 [package.metadata]
 requires-dist = [
     { name = "beautifulsoup4" },
@@ -353,8 +367,11 @@ requires-dist = [
     { name = "httpx" },
     { name = "httpx-aiohttp" },
     { name = "pydantic", specifier = "~=2.0" },
+    { name = "pytest", marker = "extra == 'dev'" },
+    { name = "pytest-asyncio", marker = "extra == 'dev'" },
     { name = "tenacity" },
 ]
+provides-extras = ["dev"]
 
 [[package]]
 name = "aviary-labbench"
@@ -364,8 +381,6 @@ dependencies = [
     { name = "fhlmi" },
     { name = "ldp" },
     { name = "paper-qa", extra = ["pymupdf"] },
-    { name = "pydantic" },
-    { name = "tenacity" },
     { name = "typing-extensions", marker = "python_full_version < '3.13'" },
 ]
 
@@ -378,6 +393,8 @@ dev = [
     { name = "pandas" },
     { name = "paper-qa" },
     { name = "pillow" },
+    { name = "pytest" },
+    { name = "pytest-asyncio" },
     { name = "tantivy", marker = "python_full_version >= '3.14'" },
 ]
 typing = [
@@ -395,9 +412,9 @@ requires-dist = [
     { name = "paper-qa", marker = "extra == 'dev'", specifier = ">=5.29.1" },
     { name = "paper-qa", extras = ["pymupdf"], specifier = ">=2025" },
     { name = "pillow", marker = "extra == 'typing'" },
-    { name = "pydantic", specifier = "~=2.0" },
+    { name = "pytest", marker = "extra == 'dev'", specifier = ">=9" },
+    { name = "pytest-asyncio", marker = "extra == 'dev'" },
     { name = "tantivy", marker = "python_full_version >= '3.14' and extra == 'dev'", specifier = ">=0.25.0" },
-    { name = "tenacity" },
     { name = "typing-extensions", marker = "python_full_version < '3.13'" },
 ]
 provides-extras = ["datasets", "dev", "typing"]
@@ -419,6 +436,8 @@ csv = [
 ]
 dev = [
     { name = "pandas" },
+    { name = "pytest" },
+    { name = "pytest-asyncio" },
 ]
 
 [package.metadata]
@@ -430,6 +449,8 @@ requires-dist = [
     { name = "pandas", marker = "extra == 'csv'" },
     { name = "paper-qa", specifier = ">=5.14.0" },
     { name = "pydantic", specifier = "~=2.0" },
+    { name = "pytest", marker = "extra == 'dev'" },
+    { name = "pytest-asyncio", marker = "extra == 'dev'" },
 ]
 provides-extras = ["csv", "dev"]
 
@@ -446,11 +467,14 @@ dependencies = [
     { name = "numpy" },
     { name = "pillow" },
     { name = "pydantic" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
 ]
 
 [package.optional-dependencies]
 dev = [
     { name = "matplotlib" },
+    { name = "pytest" },
+    { name = "pytest-asyncio" },
 ]
 
 [package.metadata]
@@ -465,6 +489,9 @@ requires-dist = [
     { name = "numpy" },
     { name = "pillow" },
     { name = "pydantic", specifier = "~=2.0" },
+    { name = "pytest", marker = "extra == 'dev'" },
+    { name = "pytest-asyncio", marker = "extra == 'dev'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
 ]
 provides-extras = ["dev"]
 
@@ -1129,6 +1156,7 @@ dependencies = [
     { name = "httpx" },
     { name = "httpx-aiohttp" },
     { name = "pydantic" },
+    { name = "pydantic-core" },
 ]
 
 [package.optional-dependencies]
@@ -1136,8 +1164,8 @@ cloud = [
     { name = "boto3" },
 ]
 dev = [
-    { name = "aviary-gsm8k", extra = ["typing"] },
-    { name = "aviary-hotpotqa" },
+    { name = "aviary-gsm8k", extra = ["dev"] },
+    { name = "aviary-hotpotqa", extra = ["dev"] },
     { name = "aviary-labbench", extra = ["dev"] },
     { name = "aviary-lfrqa", extra = ["dev"] },
     { name = "aviary-notebook", extra = ["dev"] },
@@ -1221,9 +1249,9 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "aviary-gsm8k", marker = "extra == 'gsm8k'", editable = "packages/gsm8k" },
-    { name = "aviary-gsm8k", extras = ["typing"], marker = "extra == 'dev'", editable = "packages/gsm8k" },
-    { name = "aviary-hotpotqa", marker = "extra == 'dev'", editable = "packages/hotpotqa" },
+    { name = "aviary-gsm8k", extras = ["dev"], marker = "extra == 'dev'", editable = "packages/gsm8k" },
     { name = "aviary-hotpotqa", marker = "extra == 'hotpotqa'", editable = "packages/hotpotqa" },
+    { name = "aviary-hotpotqa", extras = ["dev"], marker = "extra == 'dev'", editable = "packages/hotpotqa" },
     { name = "aviary-labbench", marker = "extra == 'labbench'", editable = "packages/labbench" },
     { name = "aviary-labbench", extras = ["dev"], marker = "extra == 'dev'", editable = "packages/labbench" },
     { name = "aviary-lfrqa", marker = "extra == 'lfrqa'", editable = "packages/lfrqa" },
@@ -1254,6 +1282,7 @@ requires-dist = [
     { name = "prek", marker = "extra == 'dev'" },
     { name = "pydantic", specifier = "~=2.0" },
     { name = "pydantic", marker = "extra == 'dev'", specifier = "~=2.9" },
+    { name = "pydantic-core" },
     { name = "pylint", marker = "extra == 'dev'", specifier = ">=4" },
     { name = "pylint-pydantic", marker = "extra == 'dev'" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=9" },

--- a/uv.lock
+++ b/uv.lock
@@ -1164,7 +1164,6 @@ dev = [
     { name = "pytest-asyncio" },
     { name = "pytest-recording" },
     { name = "pytest-rerunfailures" },
-    { name = "pytest-subtests" },
     { name = "pytest-sugar" },
     { name = "pytest-timer", extra = ["colorama"] },
     { name = "pytest-xdist" },
@@ -1257,11 +1256,10 @@ requires-dist = [
     { name = "pydantic", marker = "extra == 'dev'", specifier = "~=2.9" },
     { name = "pylint", marker = "extra == 'dev'", specifier = ">=4" },
     { name = "pylint-pydantic", marker = "extra == 'dev'" },
-    { name = "pytest", marker = "extra == 'dev'", specifier = ">=8" },
+    { name = "pytest", marker = "extra == 'dev'", specifier = ">=9" },
     { name = "pytest-asyncio", marker = "extra == 'dev'" },
     { name = "pytest-recording", marker = "extra == 'dev'" },
     { name = "pytest-rerunfailures", marker = "extra == 'dev'" },
-    { name = "pytest-subtests", marker = "extra == 'dev'" },
     { name = "pytest-sugar", marker = "extra == 'dev'" },
     { name = "pytest-timer", extras = ["colorama"], marker = "extra == 'dev'" },
     { name = "pytest-xdist", marker = "extra == 'dev'" },
@@ -3786,19 +3784,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/de/04/71e9520551fc8fe2cf5c1a1842e4e600265b0815f2016b7c27ec85688682/pytest_rerunfailures-16.1.tar.gz", hash = "sha256:c38b266db8a808953ebd71ac25c381cb1981a78ff9340a14bcb9f1b9bff1899e", size = 30889, upload-time = "2025-10-10T07:06:01.238Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/77/54/60eabb34445e3db3d3d874dc1dfa72751bfec3265bd611cb13c8b290adea/pytest_rerunfailures-16.1-py3-none-any.whl", hash = "sha256:5d11b12c0ca9a1665b5054052fcc1084f8deadd9328962745ef6b04e26382e86", size = 14093, upload-time = "2025-10-10T07:06:00.019Z" },
-]
-
-[[package]]
-name = "pytest-subtests"
-version = "0.15.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "attrs" },
-    { name = "pytest" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/bb/d9/20097971a8d315e011e055d512fa120fd6be3bdb8f4b3aa3e3c6bf77bebc/pytest_subtests-0.15.0.tar.gz", hash = "sha256:cb495bde05551b784b8f0b8adfaa27edb4131469a27c339b80fd8d6ba33f887c", size = 18525, upload-time = "2025-10-20T16:26:18.358Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/23/64/bba465299b37448b4c1b84c7a04178399ac22d47b3dc5db1874fe55a2bd3/pytest_subtests-0.15.0-py3-none-any.whl", hash = "sha256:da2d0ce348e1f8d831d5a40d81e3aeac439fec50bd5251cbb7791402696a9493", size = 9185, upload-time = "2025-10-20T16:26:17.239Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -1018,6 +1018,36 @@ wheels = [
 ]
 
 [[package]]
+name = "deptry"
+version = "0.25.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "packaging" },
+    { name = "requirements-parser" },
+    { name = "tomli", marker = "python_full_version < '3.15'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b8/b2/50ccc99362ae7757342978b7ecb3b98e47fade721fd617d74db1948ec3a1/deptry-0.25.1.tar.gz", hash = "sha256:45c8cd982c85cd4faae573ddff6920de7eec735336db6973f26a765ae7950f7d", size = 509748, upload-time = "2026-03-18T23:22:18.139Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/33/1d/b538dc635e873b25360d761cfe1fa0ccd7d6c69b698047e552f33401e60d/deptry-0.25.1-cp310-abi3-macosx_10_12_x86_64.whl", hash = "sha256:a4dd1148db24a1ddacfa8b840836c6019c2f864fcb7579dd089fd217606338c8", size = 1850319, upload-time = "2026-03-18T23:22:15.65Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/a9/511477a8f0ae4f6021d68a80bdca77e7ffb0722008dc24ee5d9ef49f5c88/deptry-0.25.1-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:c67c666d916ef12013c0772e40d78be0f21577a495d8d99ec5fcb18c332d393d", size = 1759259, upload-time = "2026-03-18T23:22:30.853Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/4b/c9f0bdda410912a6df79a789cb118fa29acae02a397794ead3c84adcda5c/deptry-0.25.1-cp310-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:58d39279828dbf4efc1abb40bf50a71b21499c36759bed5a8d8a3c0e3149b091", size = 1872012, upload-time = "2026-03-18T23:22:19.145Z" },
+    { url = "https://files.pythonhosted.org/packages/72/9c/6f6f9125bac74b5d5d2af89536cbdb3fa159b6466aa097b74e7e85e8e030/deptry-0.25.1-cp310-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:14bfcc28b4326ed8c6abb30691b19077d4ef8613cfba6c37ef5b1f471775bf6f", size = 1926575, upload-time = "2026-03-18T23:22:11.269Z" },
+    { url = "https://files.pythonhosted.org/packages/52/48/2a5e705a7f898295966ade67bd1223e2af96da433e25b39f6b9483ba2c7b/deptry-0.25.1-cp310-abi3-musllinux_1_1_aarch64.whl", hash = "sha256:555f5f9a487899ec9bf301eecba1745e14d212c4b354f4d3a5fd691e907366d3", size = 2050816, upload-time = "2026-03-18T23:22:27.439Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/c6/50f189a894e1f3bf21266299112c8a06cb731838976e1b9a9cadd0b4a86e/deptry-0.25.1-cp310-abi3-musllinux_1_1_x86_64.whl", hash = "sha256:18d21b3545ab2bfec53f3f45c6f5f201d55f713323327f8d12674505469ae6b7", size = 2145416, upload-time = "2026-03-18T23:22:24.682Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/6a/3f82f7a06217778282bc4456af1b4ffb3bc4b2c8e7891d00e8323f9ad0b8/deptry-0.25.1-cp310-abi3-win_amd64.whl", hash = "sha256:b59a560cb7dffb21832a98bb80d33d614cfb5630ea36ce21833eabf4eae3df99", size = 1718489, upload-time = "2026-03-18T23:22:28.589Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/7f/cd6b3ac8cf95f2f1c5c7a74ff6452e9098af89a9b56607381f677880641e/deptry-0.25.1-cp310-abi3-win_arm64.whl", hash = "sha256:6efffd8116fb9d2c45a251382ce4ce1c38dbb17179f581ec9231ed5390f7fc12", size = 1647020, upload-time = "2026-03-18T23:22:23.311Z" },
+    { url = "https://files.pythonhosted.org/packages/46/e7/b554568a84197c0a4177b51c9880b55e9861de08d9acfd914a08148a1faa/deptry-0.25.1-pp311-pypy311_pp73-macosx_10_12_x86_64.whl", hash = "sha256:30d64d4df1c08bc69de56cb0b4ec1f4cd9fa2e42582347d5b1eb25fd0e401745", size = 1846779, upload-time = "2026-03-18T23:22:21.887Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/63/38cf5ab4b81fcb1c58909ab0fe1ccc62b36f61c5f7d213a7d0474f620925/deptry-0.25.1-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:87bcd90f99a98bb059c7580bc315c3f87d97fe2db725530030bc974176834735", size = 1758420, upload-time = "2026-03-18T23:22:14.315Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/fb/234c333d5dfcc810bb3ca5b3b420355bdd759901c75e41f0441a9871a1cd/deptry-0.25.1-pp311-pypy311_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:80f31eb5c520651b102568dd91f738222b250a3e44c9e95d4941322109b8d40a", size = 1870345, upload-time = "2026-03-18T23:22:29.734Z" },
+    { url = "https://files.pythonhosted.org/packages/59/62/cb63e5210d1ba36cf68cdc0e4fdea73e48f80ac3b7680228816f39ff696a/deptry-0.25.1-pp311-pypy311_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:df88952a2bab7517ef23cb304b979199b28449e5d9db2e9ba9bc27a286ac852b", size = 1922759, upload-time = "2026-03-18T23:22:17.121Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/8c/e079c44ed98464930e83ca54ea5d40fec522d234e8428e06a1be7f6c7a9a/deptry-0.25.1-pp311-pypy311_pp73-musllinux_1_1_aarch64.whl", hash = "sha256:e6f7b8fa72932e51e86799b10dcd29381b2132dc799c790dca3b28ab08dffb28", size = 2049576, upload-time = "2026-03-18T23:22:12.797Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/f2/6a89ad9e5e8e9d37def57a28020d6d7fbcf900b2e5f4dfbbace349cdca91/deptry-0.25.1-pp311-pypy311_pp73-musllinux_1_1_x86_64.whl", hash = "sha256:e3fa3321078e11cd1ac3f10ce3ff0547731c53f9253b87c757a8749c76fe8fa9", size = 2144676, upload-time = "2026-03-18T23:22:26.319Z" },
+    { url = "https://files.pythonhosted.org/packages/04/9a/b3358690a1a47381d995c3d3587798ab2cd086baf4b839e35183599aa2e1/deptry-0.25.1-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:03c032c32492fde434736954fbcaff09c02bf207b0f793b77e9040300e34b344", size = 1715518, upload-time = "2026-03-18T23:22:20.486Z" },
+]
+
+[[package]]
 name = "dicttoxml"
 version = "1.7.16"
 source = { registry = "https://pypi.org/simple" }
@@ -1172,6 +1202,7 @@ dev = [
     { name = "boto3-stubs", extra = ["s3"] },
     { name = "click" },
     { name = "cloudpickle" },
+    { name = "deptry" },
     { name = "dicttoxml" },
     { name = "fastapi" },
     { name = "fhlmi" },
@@ -1262,6 +1293,7 @@ requires-dist = [
     { name = "boto3-stubs", extras = ["s3"], marker = "extra == 'typing'" },
     { name = "click", marker = "extra == 'server'" },
     { name = "cloudpickle", marker = "extra == 'server'" },
+    { name = "deptry", marker = "extra == 'dev'" },
     { name = "dicttoxml", marker = "extra == 'xml'" },
     { name = "docstring-parser", specifier = ">=0.16" },
     { name = "fastapi", marker = "extra == 'server'" },
@@ -4186,6 +4218,18 @@ wheels = [
 ]
 
 [[package]]
+name = "requirements-parser"
+version = "0.13.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "packaging" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/95/96/fb6dbfebb524d5601d359a47c78fe7ba1eef90fc4096404aa60c9a906fbb/requirements_parser-0.13.0.tar.gz", hash = "sha256:0843119ca2cb2331de4eb31b10d70462e39ace698fd660a915c247d2301a4418", size = 22630, upload-time = "2025-05-21T13:42:05.464Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bd/60/50fbb6ffb35f733654466f1a90d162bcbea358adc3b0871339254fbc37b2/requirements_parser-0.13.0-py3-none-any.whl", hash = "sha256:2b3173faecf19ec5501971b7222d38f04cb45bb9d87d0ad629ca71e2e62ded14", size = 14782, upload-time = "2025-05-21T13:42:04.007Z" },
+]
+
+[[package]]
 name = "rfc3339-validator"
 version = "0.1.4"
 source = { registry = "https://pypi.org/simple" }
@@ -4575,6 +4619,60 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/fd/18/a545c4ea42af3df6effd7d13d250ba77a0a86fb20393143bbb9a92e434d4/tokenizers-0.22.2-cp39-abi3-win32.whl", hash = "sha256:a6bf3f88c554a2b653af81f3204491c818ae2ac6fbc09e76ef4773351292bc92", size = 2502363, upload-time = "2026-01-05T10:45:20.593Z" },
     { url = "https://files.pythonhosted.org/packages/65/71/0670843133a43d43070abeb1949abfdef12a86d490bea9cd9e18e37c5ff7/tokenizers-0.22.2-cp39-abi3-win_amd64.whl", hash = "sha256:c9ea31edff2968b44a88f97d784c2f16dc0729b8b143ed004699ebca91f05c48", size = 2747786, upload-time = "2026-01-05T10:45:18.411Z" },
     { url = "https://files.pythonhosted.org/packages/72/f4/0de46cfa12cdcbcd464cc59fde36912af405696f687e53a091fb432f694c/tokenizers-0.22.2-cp39-abi3-win_arm64.whl", hash = "sha256:9ce725d22864a1e965217204946f830c37876eee3b2ba6fc6255e8e903d5fcbc", size = 2612133, upload-time = "2026-01-05T10:45:17.232Z" },
+]
+
+[[package]]
+name = "tomli"
+version = "2.4.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/22/de/48c59722572767841493b26183a0d1cc411d54fd759c5607c4590b6563a6/tomli-2.4.1.tar.gz", hash = "sha256:7c7e1a961a0b2f2472c1ac5b69affa0ae1132c39adcb67aba98568702b9cc23f", size = 17543, upload-time = "2026-03-25T20:22:03.828Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/11/db3d5885d8528263d8adc260bb2d28ebf1270b96e98f0e0268d32b8d9900/tomli-2.4.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:f8f0fc26ec2cc2b965b7a3b87cd19c5c6b8c5e5f436b984e85f486d652285c30", size = 154704, upload-time = "2026-03-25T20:21:10.473Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/f7/675db52c7e46064a9aa928885a9b20f4124ecb9bc2e1ce74c9106648d202/tomli-2.4.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:4ab97e64ccda8756376892c53a72bd1f964e519c77236368527f758fbc36a53a", size = 149454, upload-time = "2026-03-25T20:21:12.036Z" },
+    { url = "https://files.pythonhosted.org/packages/61/71/81c50943cf953efa35bce7646caab3cf457a7d8c030b27cfb40d7235f9ee/tomli-2.4.1-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:96481a5786729fd470164b47cdb3e0e58062a496f455ee41b4403be77cb5a076", size = 237561, upload-time = "2026-03-25T20:21:13.098Z" },
+    { url = "https://files.pythonhosted.org/packages/48/c1/f41d9cb618acccca7df82aaf682f9b49013c9397212cb9f53219e3abac37/tomli-2.4.1-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5a881ab208c0baf688221f8cecc5401bd291d67e38a1ac884d6736cbcd8247e9", size = 243824, upload-time = "2026-03-25T20:21:14.569Z" },
+    { url = "https://files.pythonhosted.org/packages/22/e4/5a816ecdd1f8ca51fb756ef684b90f2780afc52fc67f987e3c61d800a46d/tomli-2.4.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:47149d5bd38761ac8be13a84864bf0b7b70bc051806bc3669ab1cbc56216b23c", size = 242227, upload-time = "2026-03-25T20:21:15.712Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/49/2b2a0ef529aa6eec245d25f0c703e020a73955ad7edf73e7f54ddc608aa5/tomli-2.4.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:ec9bfaf3ad2df51ace80688143a6a4ebc09a248f6ff781a9945e51937008fcbc", size = 247859, upload-time = "2026-03-25T20:21:17.001Z" },
+    { url = "https://files.pythonhosted.org/packages/83/bd/6c1a630eaca337e1e78c5903104f831bda934c426f9231429396ce3c3467/tomli-2.4.1-cp311-cp311-win32.whl", hash = "sha256:ff2983983d34813c1aeb0fa89091e76c3a22889ee83ab27c5eeb45100560c049", size = 97204, upload-time = "2026-03-25T20:21:18.079Z" },
+    { url = "https://files.pythonhosted.org/packages/42/59/71461df1a885647e10b6bb7802d0b8e66480c61f3f43079e0dcd315b3954/tomli-2.4.1-cp311-cp311-win_amd64.whl", hash = "sha256:5ee18d9ebdb417e384b58fe414e8d6af9f4e7a0ae761519fb50f721de398dd4e", size = 108084, upload-time = "2026-03-25T20:21:18.978Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/83/dceca96142499c069475b790e7913b1044c1a4337e700751f48ed723f883/tomli-2.4.1-cp311-cp311-win_arm64.whl", hash = "sha256:c2541745709bad0264b7d4705ad453b76ccd191e64aa6f0fc66b69a293a45ece", size = 95285, upload-time = "2026-03-25T20:21:20.309Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/ba/42f134a3fe2b370f555f44b1d72feebb94debcab01676bf918d0cb70e9aa/tomli-2.4.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:c742f741d58a28940ce01d58f0ab2ea3ced8b12402f162f4d534dfe18ba1cd6a", size = 155924, upload-time = "2026-03-25T20:21:21.626Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/c7/62d7a17c26487ade21c5422b646110f2162f1fcc95980ef7f63e73c68f14/tomli-2.4.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:7f86fd587c4ed9dd76f318225e7d9b29cfc5a9d43de44e5754db8d1128487085", size = 150018, upload-time = "2026-03-25T20:21:23.002Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/05/79d13d7c15f13bdef410bdd49a6485b1c37d28968314eabee452c22a7fda/tomli-2.4.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ff18e6a727ee0ab0388507b89d1bc6a22b138d1e2fa56d1ad494586d61d2eae9", size = 244948, upload-time = "2026-03-25T20:21:24.04Z" },
+    { url = "https://files.pythonhosted.org/packages/10/90/d62ce007a1c80d0b2c93e02cab211224756240884751b94ca72df8a875ca/tomli-2.4.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:136443dbd7e1dee43c68ac2694fde36b2849865fa258d39bf822c10e8068eac5", size = 253341, upload-time = "2026-03-25T20:21:25.177Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/7e/caf6496d60152ad4ed09282c1885cca4eea150bfd007da84aea07bcc0a3e/tomli-2.4.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:5e262d41726bc187e69af7825504c933b6794dc3fbd5945e41a79bb14c31f585", size = 248159, upload-time = "2026-03-25T20:21:26.364Z" },
+    { url = "https://files.pythonhosted.org/packages/99/e7/c6f69c3120de34bbd882c6fba7975f3d7a746e9218e56ab46a1bc4b42552/tomli-2.4.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:5cb41aa38891e073ee49d55fbc7839cfdb2bc0e600add13874d048c94aadddd1", size = 253290, upload-time = "2026-03-25T20:21:27.46Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/2f/4a3c322f22c5c66c4b836ec58211641a4067364f5dcdd7b974b4c5da300c/tomli-2.4.1-cp312-cp312-win32.whl", hash = "sha256:da25dc3563bff5965356133435b757a795a17b17d01dbc0f42fb32447ddfd917", size = 98141, upload-time = "2026-03-25T20:21:28.492Z" },
+    { url = "https://files.pythonhosted.org/packages/24/22/4daacd05391b92c55759d55eaee21e1dfaea86ce5c571f10083360adf534/tomli-2.4.1-cp312-cp312-win_amd64.whl", hash = "sha256:52c8ef851d9a240f11a88c003eacb03c31fc1c9c4ec64a99a0f922b93874fda9", size = 108847, upload-time = "2026-03-25T20:21:29.386Z" },
+    { url = "https://files.pythonhosted.org/packages/68/fd/70e768887666ddd9e9f5d85129e84910f2db2796f9096aa02b721a53098d/tomli-2.4.1-cp312-cp312-win_arm64.whl", hash = "sha256:f758f1b9299d059cc3f6546ae2af89670cb1c4d48ea29c3cacc4fe7de3058257", size = 95088, upload-time = "2026-03-25T20:21:30.677Z" },
+    { url = "https://files.pythonhosted.org/packages/07/06/b823a7e818c756d9a7123ba2cda7d07bc2dd32835648d1a7b7b7a05d848d/tomli-2.4.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:36d2bd2ad5fb9eaddba5226aa02c8ec3fa4f192631e347b3ed28186d43be6b54", size = 155866, upload-time = "2026-03-25T20:21:31.65Z" },
+    { url = "https://files.pythonhosted.org/packages/14/6f/12645cf7f08e1a20c7eb8c297c6f11d31c1b50f316a7e7e1e1de6e2e7b7e/tomli-2.4.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:eb0dc4e38e6a1fd579e5d50369aa2e10acfc9cace504579b2faabb478e76941a", size = 149887, upload-time = "2026-03-25T20:21:33.028Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/e0/90637574e5e7212c09099c67ad349b04ec4d6020324539297b634a0192b0/tomli-2.4.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c7f2c7f2b9ca6bdeef8f0fa897f8e05085923eb091721675170254cbc5b02897", size = 243704, upload-time = "2026-03-25T20:21:34.51Z" },
+    { url = "https://files.pythonhosted.org/packages/10/8f/d3ddb16c5a4befdf31a23307f72828686ab2096f068eaf56631e136c1fdd/tomli-2.4.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f3c6818a1a86dd6dca7ddcaaf76947d5ba31aecc28cb1b67009a5877c9a64f3f", size = 251628, upload-time = "2026-03-25T20:21:36.012Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/f1/dbeeb9116715abee2485bf0a12d07a8f31af94d71608c171c45f64c0469d/tomli-2.4.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:d312ef37c91508b0ab2cee7da26ec0b3ed2f03ce12bd87a588d771ae15dcf82d", size = 247180, upload-time = "2026-03-25T20:21:37.136Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/74/16336ffd19ed4da28a70959f92f506233bd7cfc2332b20bdb01591e8b1d1/tomli-2.4.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:51529d40e3ca50046d7606fa99ce3956a617f9b36380da3b7f0dd3dd28e68cb5", size = 251674, upload-time = "2026-03-25T20:21:38.298Z" },
+    { url = "https://files.pythonhosted.org/packages/16/f9/229fa3434c590ddf6c0aa9af64d3af4b752540686cace29e6281e3458469/tomli-2.4.1-cp313-cp313-win32.whl", hash = "sha256:2190f2e9dd7508d2a90ded5ed369255980a1bcdd58e52f7fe24b8162bf9fedbd", size = 97976, upload-time = "2026-03-25T20:21:39.316Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/1e/71dfd96bcc1c775420cb8befe7a9d35f2e5b1309798f009dca17b7708c1e/tomli-2.4.1-cp313-cp313-win_amd64.whl", hash = "sha256:8d65a2fbf9d2f8352685bc1364177ee3923d6baf5e7f43ea4959d7d8bc326a36", size = 108755, upload-time = "2026-03-25T20:21:40.248Z" },
+    { url = "https://files.pythonhosted.org/packages/83/7a/d34f422a021d62420b78f5c538e5b102f62bea616d1d75a13f0a88acb04a/tomli-2.4.1-cp313-cp313-win_arm64.whl", hash = "sha256:4b605484e43cdc43f0954ddae319fb75f04cc10dd80d830540060ee7cd0243cd", size = 95265, upload-time = "2026-03-25T20:21:41.219Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/fb/9a5c8d27dbab540869f7c1f8eb0abb3244189ce780ba9cd73f3770662072/tomli-2.4.1-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:fd0409a3653af6c147209d267a0e4243f0ae46b011aa978b1080359fddc9b6cf", size = 155726, upload-time = "2026-03-25T20:21:42.23Z" },
+    { url = "https://files.pythonhosted.org/packages/62/05/d2f816630cc771ad836af54f5001f47a6f611d2d39535364f148b6a92d6b/tomli-2.4.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:a120733b01c45e9a0c34aeef92bf0cf1d56cfe81ed9d47d562f9ed591a9828ac", size = 149859, upload-time = "2026-03-25T20:21:43.386Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/48/66341bdb858ad9bd0ceab5a86f90eddab127cf8b046418009f2125630ecb/tomli-2.4.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:559db847dc486944896521f68d8190be1c9e719fced785720d2216fe7022b662", size = 244713, upload-time = "2026-03-25T20:21:44.474Z" },
+    { url = "https://files.pythonhosted.org/packages/df/6d/c5fad00d82b3c7a3ab6189bd4b10e60466f22cfe8a08a9394185c8a8111c/tomli-2.4.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:01f520d4f53ef97964a240a035ec2a869fe1a37dde002b57ebc4417a27ccd853", size = 252084, upload-time = "2026-03-25T20:21:45.62Z" },
+    { url = "https://files.pythonhosted.org/packages/00/71/3a69e86f3eafe8c7a59d008d245888051005bd657760e96d5fbfb0b740c2/tomli-2.4.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:7f94b27a62cfad8496c8d2513e1a222dd446f095fca8987fceef261225538a15", size = 247973, upload-time = "2026-03-25T20:21:46.937Z" },
+    { url = "https://files.pythonhosted.org/packages/67/50/361e986652847fec4bd5e4a0208752fbe64689c603c7ae5ea7cb16b1c0ca/tomli-2.4.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:ede3e6487c5ef5d28634ba3f31f989030ad6af71edfb0055cbbd14189ff240ba", size = 256223, upload-time = "2026-03-25T20:21:48.467Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/9a/b4173689a9203472e5467217e0154b00e260621caa227b6fa01feab16998/tomli-2.4.1-cp314-cp314-win32.whl", hash = "sha256:3d48a93ee1c9b79c04bb38772ee1b64dcf18ff43085896ea460ca8dec96f35f6", size = 98973, upload-time = "2026-03-25T20:21:49.526Z" },
+    { url = "https://files.pythonhosted.org/packages/14/58/640ac93bf230cd27d002462c9af0d837779f8773bc03dee06b5835208214/tomli-2.4.1-cp314-cp314-win_amd64.whl", hash = "sha256:88dceee75c2c63af144e456745e10101eb67361050196b0b6af5d717254dddf7", size = 109082, upload-time = "2026-03-25T20:21:50.506Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/2f/702d5e05b227401c1068f0d386d79a589bb12bf64c3d2c72ce0631e3bc49/tomli-2.4.1-cp314-cp314-win_arm64.whl", hash = "sha256:b8c198f8c1805dc42708689ed6864951fd2494f924149d3e4bce7710f8eb5232", size = 96490, upload-time = "2026-03-25T20:21:51.474Z" },
+    { url = "https://files.pythonhosted.org/packages/45/4b/b877b05c8ba62927d9865dd980e34a755de541eb65fffba52b4cc495d4d2/tomli-2.4.1-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:d4d8fe59808a54658fcc0160ecfb1b30f9089906c50b23bcb4c69eddc19ec2b4", size = 164263, upload-time = "2026-03-25T20:21:52.543Z" },
+    { url = "https://files.pythonhosted.org/packages/24/79/6ab420d37a270b89f7195dec5448f79400d9e9c1826df982f3f8e97b24fd/tomli-2.4.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:7008df2e7655c495dd12d2a4ad038ff878d4ca4b81fccaf82b714e07eae4402c", size = 160736, upload-time = "2026-03-25T20:21:53.674Z" },
+    { url = "https://files.pythonhosted.org/packages/02/e0/3630057d8eb170310785723ed5adcdfb7d50cb7e6455f85ba8a3deed642b/tomli-2.4.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1d8591993e228b0c930c4bb0db464bdad97b3289fb981255d6c9a41aedc84b2d", size = 270717, upload-time = "2026-03-25T20:21:55.129Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/b4/1613716072e544d1a7891f548d8f9ec6ce2faf42ca65acae01d76ea06bb0/tomli-2.4.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:734e20b57ba95624ecf1841e72b53f6e186355e216e5412de414e3c51e5e3c41", size = 278461, upload-time = "2026-03-25T20:21:56.228Z" },
+    { url = "https://files.pythonhosted.org/packages/05/38/30f541baf6a3f6df77b3df16b01ba319221389e2da59427e221ef417ac0c/tomli-2.4.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:8a650c2dbafa08d42e51ba0b62740dae4ecb9338eefa093aa5c78ceb546fcd5c", size = 274855, upload-time = "2026-03-25T20:21:57.653Z" },
+    { url = "https://files.pythonhosted.org/packages/77/a3/ec9dd4fd2c38e98de34223b995a3b34813e6bdadf86c75314c928350ed14/tomli-2.4.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:504aa796fe0569bb43171066009ead363de03675276d2d121ac1a4572397870f", size = 283144, upload-time = "2026-03-25T20:21:59.089Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/be/605a6261cac79fba2ec0c9827e986e00323a1945700969b8ee0b30d85453/tomli-2.4.1-cp314-cp314t-win32.whl", hash = "sha256:b1d22e6e9387bf4739fbe23bfa80e93f6b0373a7f1b96c6227c32bef95a4d7a8", size = 108683, upload-time = "2026-03-25T20:22:00.214Z" },
+    { url = "https://files.pythonhosted.org/packages/12/64/da524626d3b9cc40c168a13da8335fe1c51be12c0a63685cc6db7308daae/tomli-2.4.1-cp314-cp314t-win_amd64.whl", hash = "sha256:2c1c351919aca02858f740c6d33adea0c5deea37f9ecca1cc1ef9e884a619d26", size = 121196, upload-time = "2026-03-25T20:22:01.169Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/cd/e80b62269fc78fc36c9af5a6b89c835baa8af28ff5ad28c7028d60860320/tomli-2.4.1-cp314-cp314t-win_arm64.whl", hash = "sha256:eab21f45c7f66c13f2a9e0e1535309cee140182a9cdae1e041d02e47291e8396", size = 100393, upload-time = "2026-03-25T20:22:02.137Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/61/cceae43728b7de99d9b847560c262873a1f6c98202171fd5ed62640b494b/tomli-2.4.1-py3-none-any.whl", hash = "sha256:0d85819802132122da43cb86656f8d1f8c6587d54ae7dcaf30e90533028b49fe", size = 14583, upload-time = "2026-03-25T20:22:03.012Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
This PR updates our tooling:
- Pulled in `pytest` v9
- Linting dependencies using https://github.com/osprey-oss/deptry
- Modernized `pre-commit` stack