### PR TITLE
Deprecate `EnvStateMessage` in favor of `Message.info` flag

### DIFF
--- a/packages/notebook/src/aviary/envs/notebook/env.py
+++ b/packages/notebook/src/aviary/envs/notebook/env.py
@@ -11,8 +11,14 @@ from typing import Any, ClassVar, Generic, Self, TypeAlias, cast
 
 import aiodocker
 import nbformat
-from aviary.core import Environment, Message, Messages, Tool, ToolRequestMessage
-from aviary.message import EnvStateMessage
+from aviary.core import (
+    ENV_STATE_INFO_KEY,
+    Environment,
+    Message,
+    Messages,
+    Tool,
+    ToolRequestMessage,
+)
 from jupyter_client.manager import AsyncKernelManager
 from nbformat import NotebookNode
 from numpy.typing import NDArray
@@ -327,7 +333,7 @@ class NBEnvironment(Environment[TNBEnvState], Generic[TNBEnvState]):
         logger.debug("Reloading notebook from disk")
         return "Executed all cells."
 
-    def get_env_state_msg(self) -> EnvStateMessage:
+    def get_env_state_msg(self) -> Message:
         nb_path = self.state.get_container_path(self.state.nb_path)
         md_notebook, notebook_images = utils.view_notebook(
             cells=self.state.cells, language=self.language.value
@@ -335,12 +341,13 @@ class NBEnvironment(Environment[TNBEnvState], Generic[TNBEnvState]):
         # Write the markdown representation to disk
         self.state.nb_path.with_suffix(".md").write_text(md_notebook)
 
-        return EnvStateMessage.create_message(
+        return Message.create_message(
             text=(
                 "Markdown representation of notebook contents"
                 f" ({nb_path}):\n\n{md_notebook}"
             ),
             images=cast(list[NDArray[Any] | str | bytes], notebook_images),
+            info={ENV_STATE_INFO_KEY: True},
         )
 
     async def close(self):

--- a/packages/notebook/tests/test_nb_env.py
+++ b/packages/notebook/tests/test_nb_env.py
@@ -9,7 +9,6 @@ import tempfile
 
 import nbformat.v4 as nbf
 import pytest
-from aviary.message import EnvStateMessage
 
 from aviary.envs.notebook import NBEnvironment
 from aviary.envs.notebook.config import NB_ENVIRONMENT_DOCKER_IMAGE
@@ -121,7 +120,7 @@ class TestNBEnvironment:
             obs, tools = await env.reset()
 
             assert len(obs) == 1
-            assert isinstance(obs[0], EnvStateMessage)
+            assert (obs[0].info or {}).get("is_env_state")
             assert isinstance(obs[0].content, str)
             assert obs[0].content.count("Cell") == 0
 

--- a/src/aviary/core.py
+++ b/src/aviary/core.py
@@ -16,7 +16,13 @@ from aviary.env_client import (
     TaskEnvironmentClient,
 )
 from aviary.functional import DynamicState, fenv
-from aviary.message import EnvStateMessage, MalformedMessageError, Message, join
+from aviary.message import (
+    ENV_STATE_INFO_KEY,
+    EnvStateMessage,
+    MalformedMessageError,
+    Message,
+    join,
+)
 from aviary.render import Renderer
 from aviary.tools import (
     INVALID_TOOL_NAME,
@@ -50,6 +56,7 @@ from aviary.utils import (
 
 __all__ = [
     "DEFAULT_EVAL_MODEL_NAME",
+    "ENV_STATE_INFO_KEY",
     "INVALID_TOOL_NAME",
     "TASK_DATASET_REGISTRY",
     "DummyEnv",

--- a/src/aviary/message.py
+++ b/src/aviary/message.py
@@ -1,7 +1,8 @@
 import json
 import logging
-from collections.abc import Iterable
-from typing import TYPE_CHECKING, ClassVar, Self
+import warnings
+from collections.abc import Iterable, Mapping, MutableMapping
+from typing import TYPE_CHECKING, Any, ClassVar, Self
 
 from pydantic import (
     BaseModel,
@@ -311,8 +312,34 @@ class MalformedMessageError(ValueError):
         return not all(x in record.msg for x in (cls.__name__, EMPTY_CONTENT_BASE_MSG))
 
 
+ENV_STATE_INFO_KEY = "is_env_state"
+
+
 class EnvStateMessage(Message):
-    """A message that contains the current state of the environment."""
+    """A message that contains the current state of the environment.
+
+    Since this subclass is erased by `aviary.tools.base.MessagesAdapter`
+    serialization and it just becomes a Message, we are deprecating this class
+    in favor of a plain Message carrying the `ENV_STATE_INFO_KEY` flag inside `info`,
+    which survives serialization.
+    """
+
+    @model_validator(mode="before")
+    @classmethod
+    def _deprecate_and_inject_env_state_marker(
+        cls, data: MutableMapping[str, Any]
+    ) -> MutableMapping[str, Any]:
+        warnings.warn(
+            f"{cls.__name__} is deprecated; use {Message.__name__}"
+            f"(info={{{ENV_STATE_INFO_KEY!r}: True}}, ...) instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        if isinstance(data, Mapping):
+            info = dict(data.get("info") or {})
+            info[ENV_STATE_INFO_KEY] = True
+            data = {**data, "info": info}
+        return data
 
 
 # Define separately so we can filter out this message type

--- a/tests/test_messages.py
+++ b/tests/test_messages.py
@@ -5,7 +5,9 @@ import pytest
 from lmi import LiteLLMModel
 
 from aviary.core import (
+    EnvStateMessage,
     Message,
+    MessagesAdapter,
     ToolCall,
     ToolCallFunction,
     ToolRequestMessage,
@@ -214,6 +216,28 @@ class TestMessage:
         recovered = Message.model_validate(original.model_dump(mode="json"))
         assert recovered.content_is_json_str
         assert recovered.is_multimodal
+
+    def test_env_state_message_sets_info_flag_and_warns(self) -> None:
+        with pytest.warns(DeprecationWarning, match="EnvStateMessage"):
+            msg = EnvStateMessage(content="stub")
+        assert (msg.info or {}).get("is_env_state")
+
+        with pytest.warns(DeprecationWarning, match="EnvStateMessage"):
+            msg = EnvStateMessage(content="stub", info={"foo": "bar"})
+        assert (msg.info or {}) == {"foo": "bar", "is_env_state": True}, (
+            "Custom info keys must be preserved alongside the injected flag"
+        )
+
+        with pytest.warns(DeprecationWarning, match="EnvStateMessage"):
+            msg = EnvStateMessage.model_validate({"content": "stub"})
+        assert (msg.info or {}).get("is_env_state")
+
+    def test_env_state_info_flag_roundtrips_through_messages_adapter(self) -> None:
+        original = [Message(content="stub", info={"is_env_state": True})]
+        dumped = MessagesAdapter.dump_python(original, context={"include_info": True})
+        assert dumped[0]["info"]["is_env_state"]
+        (round_trip_original,) = MessagesAdapter.validate_python(dumped)
+        assert (round_trip_original.info or {}).get("is_env_state")
 
     @pytest.mark.parametrize(
         ("images", "message_text", "expected_error", "expected_content_length"),


### PR DESCRIPTION
## Summary

`EnvStateMessage(Message)` carries no fields beyond its parent — the subclass is purely a Python type tag. `TaskDatasetServer` serializes observations through `MessagesAdapter` (union of `Message | ToolRequestMessage | ToolResponseMessage`, no `EnvStateMessage`), so the subclass identity is **erased on the wire**. A remote consumer that receives the observation list gets back plain `Message` instances and cannot tell which one is the env-state snapshot, which makes server-side state-replacement (vs. accumulation) impossible to implement downstream.

This PR moves the marker from class identity into data:

- New contract: `Message.info["is_env_state"] = True` identifies an env-state observation. The server already ships `info` via `MessagesAdapter.dump_python(obs, context={"include_info": True})`, so the flag rides through dump → `validate_python` without any schema change.
- `EnvStateMessage` becomes a back-compat shim: its `__init__` injects the flag into `info` and emits a `DeprecationWarning`. Existing external callers keep working; their observations are now wire-safe.
- `NBEnvironment.get_env_state_msg` (aviary's only internal caller) is migrated off the subclass to `Message.create_message(..., info={"is_env_state": True})`. The notebook test's `isinstance` check is replaced with the info-dict check — same contract a remote consumer would use.
- New `tests/test_messages.py::test_env_state_info_flag_roundtrips_through_messages_adapter` locks in that the flag survives `MessagesAdapter.dump_python` → `validate_python`. A second test asserts the shim warns and that caller-supplied `info` keys are preserved alongside the injected flag.

## Design notes

- **Key spelling**: `"is_env_state"` (unnamespaced). Considered `"aviary.env_state_observation"`; the unnamespaced key was chosen for terseness — collisions with other future `Message.info` keys are acceptable to manage by code review.
- **Deprecation mechanism**: runtime `warnings.warn(DeprecationWarning, stacklevel=2)` only, no `typing_extensions.deprecated` decorator. Python's default filter dedupes by call site, so the warning fires once per caller location.
- **No `Message.is_env_state` helper**: the dict key is the contract; consumers check `msg.info and msg.info.get("is_env_state")` directly.
- **`core.py` re-export retained**: `aviary.core.EnvStateMessage` still imports, so external code can migrate at its own pace within the deprecation window.
- **Alternative considered**: a discriminated-union refactor (`Literal` `message_type` field + Pydantic `Field(discriminator=...)`) would preserve class identity end-to-end, but requires every wire-traveling `Message` subclass to gain a literal field and bumps the JSON schema. The info-flag is non-invasive and round-trips through the existing serialization machinery.

## Backwards compatibility

- Aviary clients pre-flag: receivers should treat absence of the key as "not env-state". A one-version window where receivers also accept the subclass keeps server-local code paths working.
- Aviary servers pre-flag: emit observations without the key; consumers fall back to existing behavior.
- Existing JSON payloads: schema-compatible, one new optional key inside the already-optional `info` dict.

## Follow-on (outside this repo)

Downstream consumers that maintain a chat history of observations should filter all entries with `info.get("is_env_state") is True` except the most recent before re-tokenizing the prompt, replacing the current state-accumulation behavior. That work lives in the consumer's observation-to-dict bridge and history-update step, not here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)