### PR TITLE
Run the `mypy` pre-commit hook serially

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -85,3 +85,4 @@ repos:
         entry: mypy
         language: system
         types_or: [python, pyi]
+        require_serial: true # mypy's SQLite cache breaks under concurrent invocations


### PR DESCRIPTION
Every open PR fails the `pre-commit` job, so nothing can go green. The `mypy` hook dies with `INTERNAL ERROR` and names no file or line.

The hook has no `require_serial`, so prek splits the file list and runs `mypy` concurrently. The workers share one `.mypy_cache`, whose metastore is SQLite, and they contend on the lock:

```
File "mypy/metastore.py", line 186, in _query
OperationalError: database is locked
```

So the failure is a race, not a version regression. The same commit crashed the 3.11 job on one run and the 3.14 job on the next, and `mypy==1.20.1` installed in both the passing and failing runs.

pre-commit's own [mirrors-mypy](https://github.com/pre-commit/mirrors-mypy) hook sets `require_serial: true` for this reason.
