### PR TITLE
Hide docstring content below \f in parameter descriptions too

### DIFF
--- a/src/aviary/tools/base.py
+++ b/src/aviary/tools/base.py
@@ -328,6 +328,12 @@ class FunctionInfo(BaseModel):
         return self.describe_str()
 
 
+def _strip_hidden(text: str) -> str:
+    r"""Return docstring above `\f` marker."""
+    before_marker, *_ = text.split("\\f", 1)
+    return before_marker.strip()
+
+
 def _raises(exc: Exception) -> NoReturn:
     """Work around lambda not supporting raise statement."""
     raise exc
@@ -404,13 +410,6 @@ class Tool(BaseModel):
         docstring = parse(function.__doc__, style=docstring_style)
         if not docstring.description:
             raise ValueError(f"Missing docstring for function {fxn_name}.")
-        # now we parse descriptions from the docstring
-        try:
-            # Don't include anything below \f, matching FastAPI's solution for this
-            # SEE: https://fastapi.tiangolo.com/advanced/path-operation-advanced-configuration/#advanced-description-from-docstring
-            description_stop_index: int | None = docstring.description.index("\\f")
-        except ValueError:
-            description_stop_index = None
         field_definitions: dict[str, tuple[type, FieldInfo]] = {}
         required: dict[str, bool] = {}
         annotations = function.__annotations__
@@ -426,6 +425,7 @@ class Tool(BaseModel):
                 ),
                 "",
             )
+            d = _strip_hidden(d)
             if not d and not allow_empty_param_descriptions:
                 raise ValueError(f"Missing description for parameter {pname}.")
             required[pname] = parameter.default == inspect.Parameter.empty
@@ -459,7 +459,7 @@ class Tool(BaseModel):
             info=FunctionInfo(
                 name=fxn_name,
                 description=partial_format(
-                    docstring.description[:description_stop_index].strip(), **formats
+                    _strip_hidden(docstring.description), **formats
                 ),
                 parameters=json_schema,
             ),

--- a/src/aviary/tools/base.py
+++ b/src/aviary/tools/base.py
@@ -329,7 +329,7 @@ class FunctionInfo(BaseModel):
 
 
 def _strip_hidden(text: str) -> str:
-    r"""Return docstring above `\f` marker."""
+    r"""Return docstring above the literal `\f` marker."""
     before_marker, *_ = text.split("\\f", 1)
     return before_marker.strip()
 

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -130,6 +130,15 @@ def example_fxn(x: int, y: str, z: float) -> None:
     assert isinstance(z, float)
 
 
+def example_fxn_linefeed_in_param(x: int) -> None:
+    r"""A test function.
+
+    Args:
+        x: x \f I should be ignored.
+    """
+    assert isinstance(x, int)
+
+
 def state_out_of_order(state: dict, x: int = 0) -> None:
     """A test function.
 
@@ -428,6 +437,29 @@ class TestTool:
                     },
                 },
                 id="with-linefeed",
+            ),
+            pytest.param(
+                example_fxn_linefeed_in_param,
+                {},
+                {
+                    "type": "function",
+                    "info": {
+                        "name": "example_fxn_linefeed_in_param",
+                        "description": "A test function.",
+                        "parameters": {
+                            "properties": {
+                                "x": {
+                                    "description": "x",
+                                    "title": "X",
+                                    "type": "integer",
+                                },
+                            },
+                            "required": ["x"],
+                            "type": "object",
+                        },
+                    },
+                },
+                id="with-linefeed-in-param",
             ),
             pytest.param(
                 # NOTE: tenacity uses `functools.wraps`: https://github.com/jd/tenacity/blob/9.1.2/tenacity/__init__.py#L330-L333


### PR DESCRIPTION
Note the deleted comment about following FastAPI was wrong, as we have been using a different convention:
* FutureHouse/Edison: `r'\f'` i.e.`'\\f'`
* FastAPI:`'\f'` i.e. form feed character